### PR TITLE
fix: android side get reactions of message null pointer error

### DIFF
--- a/android/src/main/java/com/easemob/im_flutter_sdk/EMMessageWrapper.java
+++ b/android/src/main/java/com/easemob/im_flutter_sdk/EMMessageWrapper.java
@@ -51,8 +51,10 @@ public class EMMessageWrapper extends EMWrapper implements MethodChannel.MethodC
         ArrayList<Map<String, Object>> list = new ArrayList<>();
         if (msg != null) {
             List<EMMessageReaction> reactions = msg.getMessageReaction();
-            for (int i = 0; i < reactions.size(); i++) {
-                list.add(EMMessageReactionHelper.toJson(reactions.get(i)));
+            if (reactions != null) {
+                for (int i = 0; i < reactions.size(); i++) {
+                    list.add(EMMessageReactionHelper.toJson(reactions.get(i)));
+                }
             }
         }
         onSuccess(result, channelName, list);


### PR DESCRIPTION
### 问题描述：
安卓下获取消息 Reaction 列表抛空指针异常

### 问题定位：
[EMMessageWrapper.java](https://github.com/easemob/im_flutter_sdk/blob/4.0.0+4/android/src/main/java/com/easemob/im_flutter_sdk/EMMessageWrapper.java#L53)
```java
private void reactionList(JSONObject params, String channelName, MethodChannel.Result result) throws JSONException {
      String msgId = params.getString("msgId");
      EMMessage msg = getMessageWithId(msgId);
      ArrayList<Map<String, Object>> list = new ArrayList<>();
      if (msg != null) {
          List<EMMessageReaction> reactions = msg.getMessageReaction();  // <== 可能返回 null
          for (int i = 0; i < reactions.size(); i++) {
              list.add(EMMessageReactionHelper.toJson(reactions.get(i)));
          }
      }
      onSuccess(result, channelName, list);
  }
```
[](url)