### PR TITLE
ci: add standalone Flutter CI foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
@@ -35,6 +37,8 @@ jobs:
           cache: true
 
       - name: Run quality gates
+        env:
+          FORMAT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: ./tool/ci/run_quality.sh
 
       - name: Upload Dart coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: Flutter CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - flutter2_stable
+      - '4.*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flutter-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUTTER_VERSION: 3.47.0
+
+jobs:
+  quality:
+    name: Quality and contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Run quality gates
+        run: ./tool/ci/run_quality.sh
+
+      - name: Upload Dart coverage
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: flutter-unit-coverage-${{ github.run_id }}
+          path: im_flutter_sdk/coverage/lcov.info
+          if-no-files-found: warn
+          retention-days: 7
+
+  android-build:
+    name: Android debug build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Build Android example
+        working-directory: im_flutter_sdk/example
+        run: |
+          flutter pub get
+          flutter build apk --debug
+
+  ios-build:
+    name: iOS simulator build
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Build iOS example
+        working-directory: im_flutter_sdk/example
+        run: |
+          flutter pub get
+          flutter build ios --simulator --debug --no-codesign

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   quality:
     name: Quality and contracts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Check out source
@@ -48,7 +48,7 @@ jobs:
 
   android-build:
     name: Android debug build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Check out source
@@ -76,8 +76,10 @@ jobs:
 
   ios-build:
     name: iOS simulator build
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/device-smoke.yml
+++ b/.github/workflows/device-smoke.yml
@@ -1,0 +1,102 @@
+name: Flutter Device Smoke
+
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flutter-device-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUTTER_VERSION: 3.47.0
+
+jobs:
+  android:
+    name: Android no-login Presence smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Run no-login smoke on Android emulator
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: 35
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          script: |
+            mkdir -p artifacts
+            cd im_flutter_sdk/example
+            flutter pub get
+            set -o pipefail
+            flutter test integration_test/no_login_presence_test.dart -d emulator-5554 2>&1 | tee ../../artifacts/android-no-login-smoke.log
+
+      - name: Upload Android smoke log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: flutter-device-smoke-android-${{ github.run_id }}
+          path: artifacts/android-no-login-smoke.log
+          if-no-files-found: warn
+          retention-days: 7
+
+  ios:
+    name: iOS no-login Presence smoke
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Run no-login smoke on iOS simulator
+        run: |
+          mkdir -p artifacts
+          simulator_udid="$(./tool/ci/boot_ios_simulator.sh)"
+          echo "Using iOS simulator $simulator_udid"
+          cd im_flutter_sdk/example
+          flutter pub get
+          set -o pipefail
+          flutter test integration_test/no_login_presence_test.dart -d "$simulator_udid" 2>&1 | tee ../../artifacts/ios-no-login-smoke.log
+
+      - name: Collect iOS diagnostics after failure
+        if: failure()
+        run: xcrun simctl diagnose --output artifacts/ios-sim-diagnose.tar.gz
+
+      - name: Upload iOS smoke evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: flutter-device-smoke-ios-${{ github.run_id }}
+          path: |
+            artifacts/ios-no-login-smoke.log
+            artifacts/ios-sim-diagnose.tar.gz
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/device-smoke.yml
+++ b/.github/workflows/device-smoke.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   android:
     name: Android no-login Presence smoke
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - name: Check out source
@@ -63,8 +63,10 @@ jobs:
 
   ios:
     name: iOS no-login Presence smoke
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 45
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/single-account-nightly.yml
+++ b/.github/workflows/single-account-nightly.yml
@@ -1,8 +1,6 @@
 name: Flutter Single Account Nightly
 
 on:
-  schedule:
-    - cron: '0 20 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/single-account-nightly.yml
+++ b/.github/workflows/single-account-nightly.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   android:
     name: Android login and local database
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 50
     environment: flutter-single-account
     steps:
@@ -79,8 +79,10 @@ jobs:
     name: iOS login and local database
     needs: android
     if: ${{ always() }}
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 50
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     environment: flutter-single-account
     steps:
       - name: Check out source

--- a/.github/workflows/single-account-nightly.yml
+++ b/.github/workflows/single-account-nightly.yml
@@ -1,0 +1,132 @@
+name: Flutter Single Account Nightly
+
+on:
+  schedule:
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flutter-single-account-nightly
+  cancel-in-progress: false
+
+env:
+  FLUTTER_VERSION: 3.47.0
+
+jobs:
+  android:
+    name: Android login and local database
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    environment: flutter-single-account
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Prepare protected test configuration
+        env:
+          E2E_APP_KEY: ${{ secrets.E2E_APP_KEY }}
+          E2E_USER_ID: ${{ secrets.E2E_USER_ID }}
+          E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
+        run: |
+          ./tool/ci/write_e2e_dart_defines.sh "$RUNNER_TEMP/flutter-single-account.json"
+          echo "E2E_CONFIG_PATH=$RUNNER_TEMP/flutter-single-account.json" >> "$GITHUB_ENV"
+
+      - name: Run login and local database suite on Android emulator
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: 35
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          script: |
+            mkdir -p artifacts
+            cd im_flutter_sdk/example
+            flutter pub get
+            set -o pipefail
+            flutter test integration_test/single_account_local_test.dart -d emulator-5554 --dart-define-from-file="$E2E_CONFIG_PATH" 2>&1 | tee ../../artifacts/android-single-account.log
+
+      - name: Remove protected test configuration
+        if: always()
+        run: rm -f "${E2E_CONFIG_PATH:-$RUNNER_TEMP/flutter-single-account.json}"
+
+      - name: Upload Android Nightly log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: flutter-single-account-android-${{ github.run_id }}
+          path: artifacts/android-single-account.log
+          if-no-files-found: warn
+          retention-days: 7
+
+  ios:
+    name: iOS login and local database
+    needs: android
+    if: ${{ always() }}
+    runs-on: macos-latest
+    timeout-minutes: 50
+    environment: flutter-single-account
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Prepare protected test configuration
+        env:
+          E2E_APP_KEY: ${{ secrets.E2E_APP_KEY }}
+          E2E_USER_ID: ${{ secrets.E2E_USER_ID }}
+          E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
+        run: |
+          ./tool/ci/write_e2e_dart_defines.sh "$RUNNER_TEMP/flutter-single-account.json"
+          echo "E2E_CONFIG_PATH=$RUNNER_TEMP/flutter-single-account.json" >> "$GITHUB_ENV"
+
+      - name: Run login and local database suite on iOS simulator
+        run: |
+          mkdir -p artifacts
+          simulator_udid="$(./tool/ci/boot_ios_simulator.sh)"
+          echo "Using iOS simulator $simulator_udid"
+          cd im_flutter_sdk/example
+          flutter pub get
+          set -o pipefail
+          flutter test integration_test/single_account_local_test.dart -d "$simulator_udid" --dart-define-from-file="$E2E_CONFIG_PATH" 2>&1 | tee ../../artifacts/ios-single-account.log
+
+      - name: Collect iOS diagnostics after failure
+        if: failure()
+        run: xcrun simctl diagnose --output artifacts/ios-sim-diagnose.tar.gz
+
+      - name: Remove protected test configuration
+        if: always()
+        run: rm -f "${E2E_CONFIG_PATH:-$RUNNER_TEMP/flutter-single-account.json}"
+
+      - name: Upload iOS Nightly evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: flutter-single-account-ios-${{ github.run_id }}
+          path: |
+            artifacts/ios-single-account.log
+            artifacts/ios-sim-diagnose.tar.gz
+          if-no-files-found: warn
+          retention-days: 7

--- a/im_flutter_sdk/analysis_options.yaml
+++ b/im_flutter_sdk/analysis_options.yaml
@@ -1,3 +1,15 @@
+analyzer:
+  errors:
+    # Federated packages intentionally use local path dependencies in source.
+    invalid_dependency: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/im_flutter_sdk/docs/ci/flutter-only-ci.md
+++ b/im_flutter_sdk/docs/ci/flutter-only-ci.md
@@ -1,0 +1,24 @@
+# Flutter-only CI stages
+
+These stages intentionally run without `im-test-hub`.
+
+1. `Flutter CI` is the required PR gate. It runs Dart formatting, analysis,
+   unit tests, MethodChannel contracts, package/podspec versions, the static
+   Native case mapping, and Android/iOS example builds.
+2. `Flutter Device Smoke` runs the same logged-out SDK initialization and five
+   Presence error cases on Android Emulator and iOS Simulator. It needs no
+   account or secret.
+3. `Flutter Single Account Nightly` logs in with one protected account and
+   validates native client state plus local conversation/message database
+   behavior. Android and iOS are serialized so the fixed account is never used
+   concurrently.
+
+Stage 3 reads `E2E_APP_KEY`, `E2E_USER_ID`, and `E2E_USER_PASSWORD` only from
+the protected `flutter-single-account` GitHub Environment. The workflow writes
+them to a mode-0600 temporary dart-define file, never uploads that file, and
+deletes it in an `always()` step.
+
+Cross-device message delivery, ACK/callback correlation, offline replay,
+contacts, groups, chat rooms, reactions, threads, and push are excluded here.
+Those need multiple independently controlled clients and belong in the later
+`im-test-hub` stage.

--- a/im_flutter_sdk/docs/ci/native-case-mapping.json
+++ b/im_flutter_sdk/docs/ci/native-case-mapping.json
@@ -1,0 +1,152 @@
+{
+  "schemaVersion": 1,
+  "nativeBaseline": "easemob/im-auto-test@5dd5015e60385ca2dff171bca42d83543671bc07",
+  "cases": [
+    {
+      "id": "FL-APP-001",
+      "priority": "P0",
+      "origin": "flutter-only",
+      "sourceCases": [],
+      "flutterApis": ["EMClient.init", "EMClient.isLoginBefore"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Native plugin registers and initializes while logged out"],
+      "testFile": "example/integration_test/no_login_presence_test.dart"
+    },
+    {
+      "id": "FL-PRESENCE-001",
+      "priority": "P0",
+      "origin": "native-shared",
+      "sourceCases": ["wayang.TestCase.在线状态::Presence SDK API Without Login/publishPresence"],
+      "flutterApis": ["EMPresenceManager.publishPresence"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Logged-out call throws EMError code 201"],
+      "testFile": "example/integration_test/no_login_presence_test.dart"
+    },
+    {
+      "id": "FL-PRESENCE-002",
+      "priority": "P0",
+      "origin": "native-shared",
+      "sourceCases": ["wayang.TestCase.在线状态::Presence SDK API Without Login/fetchPresenceStatus"],
+      "flutterApis": ["EMPresenceManager.fetchPresenceStatus"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Logged-out call throws EMError code 201"],
+      "testFile": "example/integration_test/no_login_presence_test.dart"
+    },
+    {
+      "id": "FL-PRESENCE-003",
+      "priority": "P0",
+      "origin": "native-shared",
+      "sourceCases": ["wayang.TestCase.在线状态::Presence SDK API Without Login/subscribe"],
+      "flutterApis": ["EMPresenceManager.subscribe"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Logged-out call throws EMError code 201"],
+      "testFile": "example/integration_test/no_login_presence_test.dart"
+    },
+    {
+      "id": "FL-PRESENCE-004",
+      "priority": "P0",
+      "origin": "native-shared",
+      "sourceCases": ["wayang.TestCase.在线状态::Presence SDK API Without Login/unsubscribe"],
+      "flutterApis": ["EMPresenceManager.unsubscribe"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Logged-out call throws EMError code 201"],
+      "testFile": "example/integration_test/no_login_presence_test.dart"
+    },
+    {
+      "id": "FL-PRESENCE-005",
+      "priority": "P0",
+      "origin": "native-shared",
+      "sourceCases": ["wayang.TestCase.在线状态::Presence SDK API Without Login/fetchSubscribedMembers"],
+      "flutterApis": ["EMPresenceManager.fetchSubscribedMembers"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Logged-out call throws EMError code 201"],
+      "testFile": "example/integration_test/no_login_presence_test.dart"
+    },
+    {
+      "id": "FL-AUTH-001",
+      "priority": "P0",
+      "origin": "native-shared",
+      "sourceCases": [
+        "wayang.TestCase.登录注册::常规登录/case1",
+        "wayang.TestCase.登录注册::查询当前用户",
+        "wayang.TestCase.登录注册::登出"
+      ],
+      "flutterApis": [
+        "EMClient.loginWithPassword",
+        "EMClient.getCurrentUserId",
+        "EMClient.isConnected",
+        "EMClient.isLoginBefore",
+        "EMClient.getAccessToken",
+        "EMClient.logout"
+      ],
+      "platforms": ["android", "ios"],
+      "assertions": ["Login succeeds and native client state matches the configured user"],
+      "testFile": "example/integration_test/single_account_local_test.dart"
+    },
+    {
+      "id": "FL-CONV-001",
+      "priority": "P1",
+      "origin": "native-shared",
+      "sourceCases": [
+        "wayang.TestCase.会话::获取会话",
+        "wayang.TestCase.会话::获取所有会话",
+        "wayang.TestCase.会话::会话扩展",
+        "wayang.TestCase.会话::删除会话"
+      ],
+      "flutterApis": ["EMChatManager.getConversation", "EMChatManager.loadAllConversations", "EMConversation.setExt", "EMChatManager.deleteConversation"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Conversation lifecycle and extension persist in the local database"],
+      "testFile": "example/integration_test/single_account_local_test.dart"
+    },
+    {
+      "id": "FL-CONV-002",
+      "priority": "P1",
+      "origin": "native-shared",
+      "sourceCases": ["wayang.TestCase.会话::插入消息", "wayang.TestCase.会话::未读数和已读", "wayang.TestCase.会话::最新消息"],
+      "flutterApis": ["EMConversation.insertMessage", "EMConversation.messagesCount", "EMConversation.unreadCount", "EMConversation.markMessageAsRead", "EMConversation.markAllMessagesAsRead", "EMConversation.latestMessage", "EMConversation.lastReceivedMessage"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Inserted messages update count, latest message, and read state"],
+      "testFile": "example/integration_test/single_account_local_test.dart"
+    },
+    {
+      "id": "FL-CONV-003",
+      "priority": "P1",
+      "origin": "native-shared",
+      "sourceCases": ["wayang.TestCase.会话::追加消息", "wayang.TestCase.会话::更新消息", "wayang.TestCase.会话::删除消息"],
+      "flutterApis": ["EMConversation.appendMessage", "EMConversation.updateMessage", "EMConversation.loadMessage", "EMConversation.deleteMessage"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Append, update, lookup, and removal are reflected in the local database"],
+      "testFile": "example/integration_test/single_account_local_test.dart"
+    },
+    {
+      "id": "FL-CONV-004",
+      "priority": "P1",
+      "origin": "native-shared",
+      "sourceCases": ["wayang.TestCase.会话::消息上下翻页"],
+      "flutterApis": ["EMConversation.loadMessages"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Up and down pagination return the expected adjacent messages"],
+      "testFile": "example/integration_test/single_account_local_test.dart"
+    },
+    {
+      "id": "FL-CONV-005",
+      "priority": "P1",
+      "origin": "native-shared",
+      "sourceCases": ["wayang.TestCase.会话::关键字搜索", "wayang.TestCase.会话::类型和条件搜索", "wayang.TestCase.会话::时间范围和本地消息数"],
+      "flutterApis": ["EMConversation.loadMessagesWithKeyword", "EMConversation.loadMessagesWithMsgType", "EMConversation.searchMsgsByOptions", "EMConversation.loadMessagesFromTime", "EMConversation.getLocalMessageCount"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Local search filters by content, type, sender, and timestamp"],
+      "testFile": "example/integration_test/single_account_local_test.dart"
+    },
+    {
+      "id": "FL-CONV-006",
+      "priority": "P1",
+      "origin": "native-shared",
+      "sourceCases": ["wayang.TestCase.会话::按消息ID删除", "wayang.TestCase.会话::按时间删除", "wayang.TestCase.会话::删除全部消息"],
+      "flutterApis": ["EMConversation.deleteMessageByIds", "EMConversation.deleteMessagesWithTs", "EMConversation.deleteAllMessages"],
+      "platforms": ["android", "ios"],
+      "assertions": ["Local deletion by id, timestamp, and all removes only the selected data"],
+      "testFile": "example/integration_test/single_account_local_test.dart"
+    }
+  ]
+}

--- a/im_flutter_sdk/example/analysis_options.yaml
+++ b/im_flutter_sdk/example/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/im_flutter_sdk/example/android/app/build.gradle.kts
+++ b/im_flutter_sdk/example/android/app/build.gradle.kts
@@ -8,8 +8,7 @@ plugins {
 android {
     namespace = "com.example.example"
     compileSdk = flutter.compileSdkVersion
-    // ndkVersion = flutter.ndkVersion
-    ndkVersion = "27.0.12077973"
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/im_flutter_sdk/example/android/gradle.properties
+++ b/im_flutter_sdk/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/im_flutter_sdk/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/im_flutter_sdk/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip

--- a/im_flutter_sdk/example/android/settings.gradle.kts
+++ b/im_flutter_sdk/example/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")

--- a/im_flutter_sdk/example/integration_test/no_login_presence_test.dart
+++ b/im_flutter_sdk/example/integration_test/no_login_presence_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:im_flutter_sdk/im_flutter_sdk.dart';
+import 'package:integration_test/integration_test.dart';
+
+const _publicAppKey = String.fromEnvironment(
+  'E2E_APP_KEY',
+  defaultValue: 'easemob#easeim',
+);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final client = EMClient.getInstance;
+
+  setUpAll(() async {
+    await client.init(
+      EMOptions.withAppKey(_publicAppKey, autoLogin: false, debugMode: false),
+    );
+
+    if (await client.isLoginBefore()) {
+      await client.logout(false);
+    }
+  });
+
+  Future<void> expectNotLoggedIn(Future<void> Function() operation) async {
+    await expectLater(
+      operation,
+      throwsA(isA<EMError>().having((error) => error.code, 'code', 201)),
+    );
+  }
+
+  testWidgets('FL-APP-001 initializes the native SDK while logged out',
+      (tester) async {
+    expect(await client.isLoginBefore(), isFalse);
+    expect(client.currentUserId, isNull);
+  });
+
+  testWidgets('FL-PRESENCE-001 rejects publish while logged out',
+      (tester) async {
+    await expectNotLoggedIn(
+      () => client.presenceManager.publishPresence('flutter-ci'),
+    );
+  });
+
+  testWidgets('FL-PRESENCE-002 rejects status fetch while logged out',
+      (tester) async {
+    await expectNotLoggedIn(
+      () => client.presenceManager
+          .fetchPresenceStatus(members: const <String>['flutter-ci-peer']),
+    );
+  });
+
+  testWidgets('FL-PRESENCE-003 rejects subscribe while logged out',
+      (tester) async {
+    await expectNotLoggedIn(
+      () => client.presenceManager.subscribe(
+        members: const <String>['flutter-ci-peer'],
+        expiry: 60,
+      ),
+    );
+  });
+
+  testWidgets('FL-PRESENCE-004 rejects unsubscribe while logged out',
+      (tester) async {
+    await expectNotLoggedIn(
+      () => client.presenceManager
+          .unsubscribe(members: const <String>['flutter-ci-peer']),
+    );
+  });
+
+  testWidgets('FL-PRESENCE-005 rejects subscription query while logged out',
+      (tester) async {
+    await expectNotLoggedIn(
+      () => client.presenceManager.fetchSubscribedMembers(
+        pageNum: 1,
+        pageSize: 20,
+      ),
+    );
+  });
+}

--- a/im_flutter_sdk/example/integration_test/single_account_local_test.dart
+++ b/im_flutter_sdk/example/integration_test/single_account_local_test.dart
@@ -1,0 +1,264 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:im_flutter_sdk/im_flutter_sdk.dart';
+import 'package:integration_test/integration_test.dart';
+
+const _appKey = String.fromEnvironment('E2E_APP_KEY');
+const _userId = String.fromEnvironment('E2E_USER_ID');
+const _password = String.fromEnvironment('E2E_USER_PASSWORD');
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final client = EMClient.getInstance;
+  var sequence = 0;
+
+  void requireConfiguration() {
+    final missing = <String>[
+      if (_appKey.isEmpty) 'E2E_APP_KEY',
+      if (_userId.isEmpty) 'E2E_USER_ID',
+      if (_password.isEmpty) 'E2E_USER_PASSWORD',
+    ];
+    if (missing.isNotEmpty) {
+      throw StateError('Missing dart-defines: ${missing.join(', ')}');
+    }
+  }
+
+  setUpAll(() async {
+    requireConfiguration();
+    await client.init(
+      EMOptions.withAppKey(_appKey, autoLogin: false, debugMode: false),
+    );
+
+    if (await client.isLoginBefore()) {
+      await client.logout(false);
+    }
+
+    await client.loginWithPassword(_userId, _password);
+    await client.startCallback();
+  });
+
+  tearDownAll(() async {
+    if (await client.isLoginBefore()) {
+      await client.logout(false);
+    }
+  });
+
+  testWidgets('FL-AUTH-001 logs in and exposes native client state',
+      (tester) async {
+    expect(await client.getCurrentUserId(), _userId);
+    expect(client.currentUserId, _userId);
+    expect(await client.isLoginBefore(), isTrue);
+    expect(await client.isConnected(), isTrue);
+    expect(await client.getAccessToken(), isNotEmpty);
+  });
+
+  group('single-account local database', () {
+    late String conversationId;
+    late EMConversation conversation;
+
+    EMMessage incoming(
+      String content, {
+      int? timestamp,
+      Map<String, dynamic>? attributes,
+    }) {
+      final time = timestamp ?? DateTime.now().millisecondsSinceEpoch;
+      return EMMessage.createReceiveMessage(
+        body: EMTextMessageBody(content: content),
+      )
+        ..from = conversationId
+        ..to = _userId
+        ..conversationId = conversationId
+        ..localTime = time
+        ..serverTime = time
+        ..hasRead = false
+        ..status = MessageStatus.SUCCESS
+        ..attributes = attributes;
+    }
+
+    setUp(() async {
+      sequence += 1;
+      conversationId =
+          'flutter_ci_${DateTime.now().microsecondsSinceEpoch}_$sequence';
+      conversation = (await client.chatManager.getConversation(
+        conversationId,
+        createIfNeed: true,
+      ))!;
+    });
+
+    tearDown(() async {
+      await client.chatManager.deleteConversation(
+        conversationId,
+        deleteMessages: true,
+      );
+    });
+
+    testWidgets(
+        'FL-CONV-001 creates, lists, extends, and deletes a conversation',
+        (tester) async {
+      final seed = incoming('conversation lifecycle seed');
+      await conversation.insertMessage(seed);
+      await conversation.setExt(const <String, String>{'owner': 'flutter-ci'});
+
+      expect(conversation.id, conversationId);
+      expect(conversation.type, EMConversationType.Chat);
+      expect(conversation.ext, const <String, String>{'owner': 'flutter-ci'});
+
+      final all = await client.chatManager.loadAllConversations();
+      expect(all.map((item) => item.id), contains(conversationId));
+
+      expect(
+        await client.chatManager.deleteConversation(
+          conversationId,
+          deleteMessages: true,
+        ),
+        isTrue,
+      );
+      expect(
+        await client.chatManager.getConversation(
+          conversationId,
+          createIfNeed: false,
+        ),
+        isNull,
+      );
+    });
+
+    testWidgets('FL-CONV-002 maintains latest, unread, and read state',
+        (tester) async {
+      final first = incoming('first', timestamp: 1000);
+      final second = incoming('second', timestamp: 2000);
+      await conversation.insertMessage(first);
+      await conversation.insertMessage(second);
+
+      expect(await conversation.messagesCount(), 2);
+      expect(await conversation.unreadCount(), 2);
+      expect((await conversation.latestMessage())?.msgId, second.msgId);
+      expect((await conversation.lastReceivedMessage())?.msgId, second.msgId);
+      expect((await conversation.loadMessage(first.msgId))?.msgId, first.msgId);
+
+      await conversation.markMessageAsRead(first.msgId);
+      expect(await conversation.unreadCount(), 1);
+      await conversation.markAllMessagesAsRead();
+      expect(await conversation.unreadCount(), 0);
+    });
+
+    testWidgets('FL-CONV-003 appends, updates, loads, and removes a message',
+        (tester) async {
+      final message = incoming('before update');
+      await conversation.appendMessage(message);
+      expect((await conversation.loadMessage(message.msgId))?.msgId,
+          message.msgId);
+
+      message.body = EMTextMessageBody(content: 'after update');
+      await conversation.updateMessage(message);
+      final updated = await conversation.loadMessage(message.msgId);
+      expect((updated?.body as EMTextMessageBody).content, 'after update');
+
+      await conversation.deleteMessage(message.msgId);
+      expect(await conversation.loadMessage(message.msgId), isNull);
+    });
+
+    testWidgets('FL-CONV-004 pages local messages upward and downward',
+        (tester) async {
+      final first = incoming('page 1', timestamp: 1000);
+      final second = incoming('page 2', timestamp: 2000);
+      final third = incoming('page 3', timestamp: 3000);
+      for (final message in <EMMessage>[first, second, third]) {
+        await conversation.insertMessage(message);
+      }
+
+      final older = await conversation.loadMessages(
+        startMsgId: third.msgId,
+        loadCount: 2,
+        direction: EMSearchDirection.Up,
+      );
+      expect(
+          older.map((item) => item.msgId),
+          containsAll(<String>[
+            first.msgId,
+            second.msgId,
+          ]));
+
+      final newer = await conversation.loadMessages(
+        startMsgId: first.msgId,
+        loadCount: 2,
+        direction: EMSearchDirection.Down,
+      );
+      expect(
+          newer.map((item) => item.msgId),
+          containsAll(<String>[
+            second.msgId,
+            third.msgId,
+          ]));
+    });
+
+    testWidgets(
+        'FL-CONV-005 searches local messages by content, type, and options',
+        (tester) async {
+      final first = incoming(
+        'flutter needle alpha',
+        timestamp: 1000,
+        attributes: <String, dynamic>{'suite': 'flutter-ci'},
+      );
+      final second = incoming('ordinary beta', timestamp: 2000);
+      await conversation.insertMessage(first);
+      await conversation.insertMessage(second);
+
+      final keyword = await conversation.loadMessagesWithKeyword(
+        'needle',
+        count: 10,
+      );
+      expect(keyword.map((item) => item.msgId), contains(first.msgId));
+
+      final texts = await conversation.loadMessagesWithMsgType(
+        type: MessageType.TXT,
+        count: 10,
+      );
+      expect(
+          texts.map((item) => item.msgId),
+          containsAll(<String>[
+            first.msgId,
+            second.msgId,
+          ]));
+
+      final options = await conversation.searchMsgsByOptions(
+        MessageSearchOptions(
+          types: const <MessageType>[MessageType.TXT],
+          from: conversationId,
+          count: 10,
+        ),
+      );
+      expect(options.map((item) => item.msgId), contains(first.msgId));
+
+      final inRange = await conversation.loadMessagesFromTime(
+        startTime: 500,
+        endTime: 1500,
+        count: 10,
+      );
+      expect(inRange.map((item) => item.msgId), contains(first.msgId));
+      expect(
+        await conversation.getLocalMessageCount(startMs: 500, endMs: 2500),
+        2,
+      );
+    });
+
+    testWidgets('FL-CONV-006 deletes local messages by id, time, and all',
+        (tester) async {
+      final first = incoming('delete by id', timestamp: 1000);
+      final second = incoming('delete by time', timestamp: 2000);
+      final third = incoming('delete all', timestamp: 3000);
+      for (final message in <EMMessage>[first, second, third]) {
+        await conversation.insertMessage(message);
+      }
+
+      await conversation.deleteMessageByIds(<String>[first.msgId]);
+      expect(await conversation.loadMessage(first.msgId), isNull);
+
+      await conversation.deleteMessagesWithTs(1500, 2500);
+      expect(await conversation.loadMessage(second.msgId), isNull);
+      expect(await conversation.loadMessage(third.msgId), isNotNull);
+
+      await conversation.deleteAllMessages();
+      expect(await conversation.messagesCount(), 0);
+    });
+  });
+}

--- a/im_flutter_sdk/example/ios/Podfile
+++ b/im_flutter_sdk/example/ios/Podfile
@@ -1,5 +1,4 @@
-# Uncomment this line to define a global platform for your project
-# platform :ios, '13.0'
+platform :ios, '15.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/im_flutter_sdk/example/ios/Podfile.lock
+++ b/im_flutter_sdk/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Flutter (1.0.0)
   - HyphenateChat (4.19.1):
     - ShengwangInfra_iOS (~> 1.3.0)
-  - im_flutter_sdk_ios (4.15.2):
+  - im_flutter_sdk_ios (4.19.2):
     - Flutter
     - HyphenateChat (= 4.19.1)
   - ShengwangInfra_iOS (1.3.5)
@@ -23,11 +23,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/im_flutter_sdk_ios/ios"
 
 SPEC CHECKSUMS:
-  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  Flutter: 71a624a5bc0c04062bf19101d501e466baf2fb47
   HyphenateChat: 6e84d205716ada52bd955ae56a2ace1735d255de
-  im_flutter_sdk_ios: 8cc34d8a82136bd35a9ff59fff6bc6736ff45c23
+  im_flutter_sdk_ios: 4e544822e9ed74b71e2e9a52222049e2fdb2a09b
   ShengwangInfra_iOS: 0ae2d429ec428cdbaebb39ac883ec64c5c20f7bb
 
-PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+PODFILE CHECKSUM: ce2a4dd764e1c7aeed6a7cdc5e61d092b6dc6d32
 
 COCOAPODS: 1.16.2

--- a/im_flutter_sdk/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/im_flutter_sdk/example/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +66,7 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B073DB20E418666D8231E9F9 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -72,6 +74,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				5A80D467FBBEAF714D6B730D /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -120,6 +123,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -187,6 +191,9 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -212,6 +219,9 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -454,7 +464,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -584,7 +594,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -635,7 +645,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -725,6 +735,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/im_flutter_sdk/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/im_flutter_sdk/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/im_flutter_sdk/example/pubspec.lock
+++ b/im_flutter_sdk/example/pubspec.lock
@@ -57,8 +57,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -72,6 +85,11 @@ packages:
     version: "4.0.0"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -103,6 +121,11 @@ packages:
       relative: true
     source: path
     version: "4.19.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -139,10 +162,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -155,10 +178,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   path:
     dependency: transitive
     description:
@@ -167,6 +190,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -175,6 +206,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -212,6 +251,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -224,18 +271,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -244,6 +291,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.3.1"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.11.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/im_flutter_sdk/example/pubspec.yaml
+++ b/im_flutter_sdk/example/pubspec.yaml
@@ -47,6 +47,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/im_flutter_sdk/lib/src/managers/chat_manager.dart
+++ b/im_flutter_sdk/lib/src/managers/chat_manager.dart
@@ -1922,609 +1922,611 @@ class EMChatManager {
     }
   }
 
-  /// ~english
-  /// Gets all languages supported by the translation service.
-  ///
-  /// **Return** The supported languages.
-  ///
-  /// **Throws** A description of the exception. See [EMError].
-  /// ~end
-  ///
-  /// ~chinese
-  /// 查询翻译服务支持的语言。
-  ///
-  /// **Return** 翻译服务支持的语言列表。
-  ///
-  /// **Throws** 如果有异常会在此抛出，包括错误码和错误信息，详见 [EMError]。
-  /// ~end
 
-  Future<List<EMTranslateLanguage>> fetchSupportedLanguages() async {
-    try {
-      Map result = await Client.instance.chatManager
-          .callNativeMethod(ChatMethodKeys.fetchSupportLanguages);
-      EMError.hasErrorFromResult(result);
-      List<EMTranslateLanguage> list = [];
-      result[ChatMethodKeys.fetchSupportLanguages]?.forEach((element) {
-        list.add(EMTranslateLanguage.fromJson(element));
-      });
-      return list;
-    } catch (e) {
-      rethrow;
-    }
+/// ~english
+/// Gets all languages supported by the translation service.
+///
+/// **Return** The supported languages.
+///
+/// **Throws** A description of the exception. See [EMError].
+/// ~end
+///
+/// ~chinese
+/// 查询翻译服务支持的语言。
+///
+/// **Return** 翻译服务支持的语言列表。
+///
+/// **Throws** 如果有异常会在此抛出，包括错误码和错误信息，详见 [EMError]。
+/// ~end
+
+Future<List<EMTranslateLanguage>> fetchSupportedLanguages() async {
+  try {
+    Map result = await Client.instance.chatManager
+        .callNativeMethod(ChatMethodKeys.fetchSupportLanguages);
+    EMError.hasErrorFromResult(result);
+    List<EMTranslateLanguage> list = [];
+    result[ChatMethodKeys.fetchSupportLanguages]?.forEach((element) {
+      list.add(EMTranslateLanguage.fromJson(element));
+    });
+    return list;
+  } catch (e) {
+    rethrow;
   }
+}
 
-  @Deprecated('Use [fetchConversationsByOptions] instead')
+@Deprecated('Use [fetchConversationsByOptions] instead')
 
-  /// ~english
-  /// Gets the list of pinned conversations from the server with pagination.
-  ///
-  /// The SDK returns the pinned conversations in the reverse chronological order of their pinning.
-  ///
-  /// Param [cursor] The position from which to start getting data. If this parameter is not set, the SDK retrieves conversations from the latest pinned one.
-  ///
-  /// Param [pageSize] The number of conversations that you expect to get on each page. The value range is [1,50].
-  ///
-  /// **Return** The pinned conversation list of the current user.
-  ///
-  /// **Throws** A description of the exception. See [EMError].
-  /// ~end
-  ///
-  /// ~chinese
-  /// 分页从服务器获取置顶会话。
-  ///
-  /// SDK 按照会话的置顶时间的倒序返回会话列表。
-  ///
-  /// Param [cursor] 查询的开始位置，如不传， SDK 从最新置顶的会话开始查询。
-  ///
-  /// Param [pageSize] 每页期望返回的会话数量。取值范围为 [1,50]。
-  ///
-  /// **Return** 当前用户的置顶会话列表。
-  ///
-  /// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-  /// ~end
-  Future<EMCursorResult<EMConversation>> fetchPinnedConversations({
-    String? cursor,
-    int pageSize = 20,
-  }) async {
-    try {
-      Map map = {
-        "pageSize": pageSize,
-      };
-      map.putIfNotNull('cursor', cursor);
-      Map result = await Client.instance.chatManager.callNativeMethod(
-        ChatMethodKeys.getPinnedConversationsFromServerWithCursor,
-        map,
-      );
-      EMError.hasErrorFromResult(result);
-      return EMCursorResult.fromJson(
-          result[ChatMethodKeys.getPinnedConversationsFromServerWithCursor],
-          dataItemCallback: (map) {
-        return EMConversation.fromJson(map);
-      });
-    } catch (e) {
-      rethrow;
-    }
+/// ~english
+/// Gets the list of pinned conversations from the server with pagination.
+///
+/// The SDK returns the pinned conversations in the reverse chronological order of their pinning.
+///
+/// Param [cursor] The position from which to start getting data. If this parameter is not set, the SDK retrieves conversations from the latest pinned one.
+///
+/// Param [pageSize] The number of conversations that you expect to get on each page. The value range is [1,50].
+///
+/// **Return** The pinned conversation list of the current user.
+///
+/// **Throws** A description of the exception. See [EMError].
+/// ~end
+///
+/// ~chinese
+/// 分页从服务器获取置顶会话。
+///
+/// SDK 按照会话的置顶时间的倒序返回会话列表。
+///
+/// Param [cursor] 查询的开始位置，如不传， SDK 从最新置顶的会话开始查询。
+///
+/// Param [pageSize] 每页期望返回的会话数量。取值范围为 [1,50]。
+///
+/// **Return** 当前用户的置顶会话列表。
+///
+/// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+/// ~end
+Future<EMCursorResult<EMConversation>> fetchPinnedConversations({
+  String? cursor,
+  int pageSize = 20,
+}) async {
+  try {
+    Map map = {
+      "pageSize": pageSize,
+    };
+    map.putIfNotNull('cursor', cursor);
+    Map result = await Client.instance.chatManager.callNativeMethod(
+      ChatMethodKeys.getPinnedConversationsFromServerWithCursor,
+      map,
+    );
+    EMError.hasErrorFromResult(result);
+    return EMCursorResult.fromJson(
+        result[ChatMethodKeys.getPinnedConversationsFromServerWithCursor],
+        dataItemCallback: (map) {
+      return EMConversation.fromJson(map);
+    });
+  } catch (e) {
+    rethrow;
   }
+}
 
-  /// ~english
-  /// Sets whether to pin a conversation.
-  ///
-  /// Param [conversationId] The conversation ID.
-  ///
-  /// Param [isPinned]  Whether to pin a conversation:
-  /// - true: Pin the conversation.
-  /// - false: Unpin the conversation.
-  ///
-  /// **Throws** A description of the exception. See [EMError].
-  /// ~end
-  ///
-  /// ~chinese
-  /// 设置是否置顶会话。
-  ///
-  /// Param [conversationId] 会话 ID。
-  ///
-  /// Param [isPinned] 是否置顶会话：
-  /// - true: 置顶会话。
-  /// - false: 取消置顶会话。
-  ///
-  /// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-  /// ~end
+/// ~english
+/// Sets whether to pin a conversation.
+///
+/// Param [conversationId] The conversation ID.
+///
+/// Param [isPinned]  Whether to pin a conversation:
+/// - true: Pin the conversation.
+/// - false: Unpin the conversation.
+///
+/// **Throws** A description of the exception. See [EMError].
+/// ~end
+///
+/// ~chinese
+/// 设置是否置顶会话。
+///
+/// Param [conversationId] 会话 ID。
+///
+/// Param [isPinned] 是否置顶会话：
+/// - true: 置顶会话。
+/// - false: 取消置顶会话。
+///
+/// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+/// ~end
 
-  Future<void> pinConversation(
-      {required String conversationId, required bool isPinned}) async {
-    try {
-      Map map = {
-        'convId': conversationId,
-        'isPinned': isPinned,
-      };
+Future<void> pinConversation(
+    {required String conversationId, required bool isPinned}) async {
+  try {
+    Map map = {
+      'convId': conversationId,
+      'isPinned': isPinned,
+    };
 
-      Map result = await Client.instance.chatManager.callNativeMethod(
-        ChatMethodKeys.pinConversation,
-        map,
-      );
-      EMError.hasErrorFromResult(result);
-    } catch (e) {
-      rethrow;
-    }
+    Map result = await Client.instance.chatManager.callNativeMethod(
+      ChatMethodKeys.pinConversation,
+      map,
+    );
+    EMError.hasErrorFromResult(result);
+  } catch (e) {
+    rethrow;
   }
+}
 
-  /// ~english
-  /// Modifies a message.
-  ///
-  /// After this method is called to modify a message, both the local message and the message on the server are modified.
-  ///
-  /// This method can only modify a text message in one-to-one chats or group chats, but not in chat rooms.
-  ///
-  /// Param [messageId] The ID of the message to modify.
-  ///
-  /// Param [msgBody]  The modified message body [EMMessageBody], only [EMTextMessageBody] and [EMCustomMessageBody] are supported.
-  ///
-  /// Param [attributes] The custom attributes of the message.
-  ///
-  /// **Return** The modified message.
-  ///
-  /// **Throws** A description of the exception. See [EMError].
-  /// ~end
-  ///
-  /// ~chinese
-  /// 修改消息内容。
-  ///
-  /// 调用该方法修改消息内容后，本地和服务端的消息均会修改。
-  ///
-  /// 只能调用该方法修改单聊和群聊中的文本消息，不能修改聊天室消息。
-  ///
-  /// Param [messageId] 消息实例 ID。
-  ///
-  /// Param [msgBody] 息体实例 [EMMessageBody], 只支持 [EMTextMessageBody], [EMCustomMessageBody]。
-  ///
-  /// Param [attributes] 消息的扩展字段
-  ///
-  /// **Return** 修改后的消息实例。
-  ///
-  /// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-  /// ~end
+/// ~english
+/// Modifies a message.
+///
+/// After this method is called to modify a message, both the local message and the message on the server are modified.
+///
+/// This method can only modify a text message in one-to-one chats or group chats, but not in chat rooms.
+///
+/// Param [messageId] The ID of the message to modify.
+///
+/// Param [msgBody]  The modified message body [EMMessageBody], only [EMTextMessageBody] and [EMCustomMessageBody] are supported.
+///
+/// Param [attributes] The custom attributes of the message.
+///
+/// **Return** The modified message.
+///
+/// **Throws** A description of the exception. See [EMError].
+/// ~end
+///
+/// ~chinese
+/// 修改消息内容。
+///
+/// 调用该方法修改消息内容后，本地和服务端的消息均会修改。
+///
+/// 只能调用该方法修改单聊和群聊中的文本消息，不能修改聊天室消息。
+///
+/// Param [messageId] 消息实例 ID。
+///
+/// Param [msgBody] 息体实例 [EMMessageBody], 只支持 [EMTextMessageBody], [EMCustomMessageBody]。
+///
+/// Param [attributes] 消息的扩展字段
+///
+/// **Return** 修改后的消息实例。
+///
+/// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+/// ~end
 
-  Future<EMMessage> modifyMessage({
-    required String messageId,
-    EMMessageBody? msgBody,
-    Map<String, dynamic>? attributes,
-  }) async {
-    try {
-      Map map = {'msgId': messageId};
-      map.putIfNotNull('msgBody', msgBody?.toJson());
-      map.putIfNotNull('attributes', attributes);
+Future<EMMessage> modifyMessage({
+  required String messageId,
+  EMMessageBody? msgBody,
+  Map<String, dynamic>? attributes,
+}) async {
+  try {
+    Map map = {'msgId': messageId};
+    map.putIfNotNull('msgBody', msgBody?.toJson());
+    map.putIfNotNull('attributes', attributes);
 
-      Map result = await Client.instance.chatManager.callNativeMethod(
-        ChatMethodKeys.modifyMessage,
-        map,
-      );
-      EMError.hasErrorFromResult(result);
-      return EMMessage.fromJson(result[ChatMethodKeys.modifyMessage]);
-    } catch (e) {
-      rethrow;
-    }
+    Map result = await Client.instance.chatManager.callNativeMethod(
+      ChatMethodKeys.modifyMessage,
+      map,
+    );
+    EMError.hasErrorFromResult(result);
+    return EMMessage.fromJson(result[ChatMethodKeys.modifyMessage]);
+  } catch (e) {
+    rethrow;
   }
+}
 
-  /// ~english
-  /// Gets the details of a combined message.
-  ///
-  /// Param [message] The combined message.
-  ///
-  /// **Return** The list of original messages included in the combined message.
-  ///
-  /// **Throws** A description of the exception. See [EMError].
-  /// ~end
-  ///
-  /// ~chinese
-  /// 获取合并消息的详情。
-  ///
-  /// Param [message] 合并消息。
-  ///
-  /// **Return** 合并消息包含的原始消息列表。
-  ///
-  /// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-  /// ~end
+/// ~english
+/// Gets the details of a combined message.
+///
+/// Param [message] The combined message.
+///
+/// **Return** The list of original messages included in the combined message.
+///
+/// **Throws** A description of the exception. See [EMError].
+/// ~end
+///
+/// ~chinese
+/// 获取合并消息的详情。
+///
+/// Param [message] 合并消息。
+///
+/// **Return** 合并消息包含的原始消息列表。
+///
+/// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+/// ~end
 
-  Future<List<EMMessage>> fetchCombineMessageDetail({
-    required EMMessage message,
-  }) async {
-    try {
-      Map map = {
-        'message': message.toJson(),
-      };
+Future<List<EMMessage>> fetchCombineMessageDetail({
+  required EMMessage message,
+}) async {
+  try {
+    Map map = {
+      'message': message.toJson(),
+    };
 
-      Map result = await Client.instance.chatManager.callNativeMethod(
-        ChatMethodKeys.downloadAndParseCombineMessage,
-        map,
-      );
+    Map result = await Client.instance.chatManager.callNativeMethod(
+      ChatMethodKeys.downloadAndParseCombineMessage,
+      map,
+    );
 
-      EMError.hasErrorFromResult(result);
-      List<EMMessage> messages = [];
-      List list = result[ChatMethodKeys.downloadAndParseCombineMessage];
-      for (var element in list) {
-        messages.add(EMMessage.fromJson(element));
-      }
-      return messages;
-    } catch (e) {
-      rethrow;
+    EMError.hasErrorFromResult(result);
+    List<EMMessage> messages = [];
+    List list = result[ChatMethodKeys.downloadAndParseCombineMessage];
+    for (var element in list) {
+      messages.add(EMMessage.fromJson(element));
     }
+    return messages;
+  } catch (e) {
+    rethrow;
   }
+}
 
-  ///
-  /// ~english
-  /// Marks conversations.
-  ///
-  /// This method marks conversations both locally and on the server.
-  ///
-  /// Param [conversationIds] The list of conversation IDs to mark.
-  ///
-  /// Param [mark] The mark to add for the conversations. See [ConversationMarkType].
-  ///
-  /// **Throws** A description of the exception. See [EMError].
-  ///
-  /// ~end
-  ///
-  /// ~chinese
-  /// 标记会话。
-  ///
-  /// 调用该方法会同时为本地和服务器端的会话添加标记。
-  ///
-  /// Param [conversationIds] 要标记的会话 ID 列表。
-  ///
-  /// Param [mark] 要添加的会话标记，详见 [ConversationMarkType]。
-  ///
-  /// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-  ///
-  /// ~end
+///
+/// ~english
+/// Marks conversations.
+///
+/// This method marks conversations both locally and on the server.
+///
+/// Param [conversationIds] The list of conversation IDs to mark.
+///
+/// Param [mark] The mark to add for the conversations. See [ConversationMarkType].
+///
+/// **Throws** A description of the exception. See [EMError].
+///
+/// ~end
+///
+/// ~chinese
+/// 标记会话。
+///
+/// 调用该方法会同时为本地和服务器端的会话添加标记。
+///
+/// Param [conversationIds] 要标记的会话 ID 列表。
+///
+/// Param [mark] 要添加的会话标记，详见 [ConversationMarkType]。
+///
+/// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+///
+/// ~end
 
-  Future<void> addRemoteAndLocalConversationsMark({
-    required List<String> conversationIds,
-    required ConversationMarkType mark,
-  }) async {
-    try {
-      Map map = {
-        'convIds': conversationIds,
-        'mark': mark.index,
-      };
+Future<void> addRemoteAndLocalConversationsMark({
+  required List<String> conversationIds,
+  required ConversationMarkType mark,
+}) async {
+  try {
+    Map map = {
+      'convIds': conversationIds,
+      'mark': mark.index,
+    };
 
-      Map result = await Client.instance.chatManager.callNativeMethod(
-        ChatMethodKeys.addRemoteAndLocalConversationsMark,
-        map,
-      );
-      EMError.hasErrorFromResult(result);
-    } catch (e) {
-      rethrow;
+    Map result = await Client.instance.chatManager.callNativeMethod(
+      ChatMethodKeys.addRemoteAndLocalConversationsMark,
+      map,
+    );
+    EMError.hasErrorFromResult(result);
+  } catch (e) {
+    rethrow;
+  }
+}
+
+/// ~english
+/// Unmarks conversations.
+///
+/// This method unmarks conversations both locally and on the server.
+///
+/// Param [conversationIds] The list of conversation IDs to unmark.
+/// Param [mark] The conversation mark to remove. See [ConversationMarkType].
+/// ~end
+///
+/// ~chinese
+/// 取消标记会话。
+///
+/// 本地和服务端取消标记会话。
+///
+/// Param [conversationIds] 要取消标记的会话 ID 列表。
+/// Param [mark] 要移除的会话标记，详见 [ConversationMarkType]。
+/// ~end
+
+Future<void> deleteRemoteAndLocalConversationsMark({
+  required List<String> conversationIds,
+  required ConversationMarkType mark,
+}) async {
+  try {
+    Map map = {
+      'convIds': conversationIds,
+      'mark': mark.index,
+    };
+
+    Map result = await Client.instance.chatManager.callNativeMethod(
+      ChatMethodKeys.deleteRemoteAndLocalConversationsMark,
+      map,
+    );
+
+    EMError.hasErrorFromResult(result);
+  } catch (e) {
+    rethrow;
+  }
+}
+
+/// ~english
+/// Gets conversations from the server by conversation filter options.
+///
+/// Param [options] The conversation filter options. See [ConversationFetchOptions].
+/// Returns The list of retrieved conversations.
+/// Throws A description of the exception. See [EMError].
+/// ~end
+/// ~chinese
+/// 根据会话过滤选项获取服务端的会话。
+/// Param [options] 会话过滤选项, 详见 [ConversationFetchOptions]。
+/// Returns 会话列表。
+/// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+/// ~end
+
+Future<EMCursorResult<EMConversation>> fetchConversationsByOptions({
+  required ConversationFetchOptions options,
+}) async {
+  try {
+    Map req = options.toJson();
+    Map result = await Client.instance.chatManager
+        .callNativeMethod(ChatMethodKeys.fetchConversationsByOptions, req);
+    EMError.hasErrorFromResult(result);
+    return EMCursorResult<EMConversation>.fromJson(
+        result[ChatMethodKeys.fetchConversationsByOptions],
+        dataItemCallback: (value) {
+      return EMConversation.fromJson(value);
+    });
+  } catch (e) {
+    rethrow;
+  }
+}
+
+/// ~english
+/// Clears all conversations and all messages in them.
+/// Param [clearServerData] Whether to clear all conversations and all messages in them on the server.
+/// - true: Yes. All conversations and all messages in them will be cleared on the server side.
+///   The current user cannot retrieve messages and conversations from the server, while this has no impact on other users.
+/// - (Default) false：No. All local conversations and all messages in them will be cleared, while those on the server remain.
+/// ~end
+///
+/// ~chinese
+/// 清空所有会话和会话中的所有消息。
+/// Param [clearServerData] 是否删除服务端所有会话及其消息：
+/// - true: 是。服务端的所有会话及其消息会被清除，当前用户无法再从服务端拉取消息和会话，其他用户不受影响。
+/// - （默认）false: 否。只清除本地所有会话及其消息，服务端的会话及其消息仍保留。
+/// ~end
+
+Future<void> deleteAllMessageAndConversation(
+    {bool clearServerData = false}) async {
+  try {
+    Map result = await Client.instance.chatManager
+        .callNativeMethod(ChatMethodKeys.deleteAllMessageAndConversation, {
+      'clearServerData': clearServerData,
+    });
+    EMError.hasErrorFromResult(result);
+  } catch (e) {
+    rethrow;
+  }
+}
+
+/// ~english
+/// Pins a message.
+/// Param [messageId] The message ID.
+///
+/// Throws A description of the exception. See [EMError].
+/// ~end
+///
+/// ~chinese
+/// 置顶消息。
+/// Param [messageId] 消息 ID。
+///
+/// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+/// ~end
+
+Future<void> pinMessage({required String messageId}) async {
+  try {
+    Map map = {'msgId': messageId};
+    Map result = await Client.instance.chatManager.callNativeMethod(
+      ChatMethodKeys.pinMessage,
+      map,
+    );
+    EMError.hasErrorFromResult(result);
+  } catch (e) {
+    rethrow;
+  }
+}
+
+/// ~english
+/// Unpins a message.
+///
+/// Param [messageId] The message ID.
+///
+/// Throws A description of the exception. See [EMError].
+/// ~end
+/// ~chinese
+/// 取消置顶消息。
+///
+/// Param [messageId] 消息 ID。
+///
+/// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+/// ~end
+
+Future<void> unpinMessage({required String messageId}) async {
+  try {
+    Map map = {'msgId': messageId};
+    Map result = await Client.instance.chatManager.callNativeMethod(
+      ChatMethodKeys.unpinMessage,
+      map,
+    );
+    EMError.hasErrorFromResult(result);
+  } catch (e) {
+    rethrow;
+  }
+}
+
+/// ~english
+/// Gets the list of pinned messages from the server.
+///
+/// Param [conversationId] The conversation ID.
+/// Returns The list of pinned messages.
+/// Throws A description of the exception. See [EMError].
+/// ~end
+/// ~chinese
+/// 从服务端获取置顶消息。
+///
+/// Param [conversationId] 会话 ID。
+/// Returns 置顶消息列表。
+/// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+/// ~end
+
+Future<List<EMMessage>> fetchPinnedMessages(
+    {required String conversationId}) async {
+  try {
+    Map map = {'convId': conversationId};
+    Map result = await Client.instance.chatManager.callNativeMethod(
+      ChatMethodKeys.fetchPinnedMessages,
+      map,
+    );
+    EMError.hasErrorFromResult(result);
+    List<EMMessage> messages = [];
+    List list = result[ChatMethodKeys.fetchPinnedMessages];
+    for (var element in list) {
+      messages.add(EMMessage.fromJson(element));
     }
+    return messages;
+  } catch (e) {
+    rethrow;
   }
-
-  /// ~english
-  /// Unmarks conversations.
-  ///
-  /// This method unmarks conversations both locally and on the server.
-  ///
-  /// Param [conversationIds] The list of conversation IDs to unmark.
-  /// Param [mark] The conversation mark to remove. See [ConversationMarkType].
-  /// ~end
-  ///
-  /// ~chinese
-  /// 取消标记会话。
-  ///
-  /// 本地和服务端取消标记会话。
-  ///
-  /// Param [conversationIds] 要取消标记的会话 ID 列表。
-  /// Param [mark] 要移除的会话标记，详见 [ConversationMarkType]。
-  /// ~end
-
-  Future<void> deleteRemoteAndLocalConversationsMark({
-    required List<String> conversationIds,
-    required ConversationMarkType mark,
-  }) async {
-    try {
-      Map map = {
-        'convIds': conversationIds,
-        'mark': mark.index,
-      };
-
-      Map result = await Client.instance.chatManager.callNativeMethod(
-        ChatMethodKeys.deleteRemoteAndLocalConversationsMark,
-        map,
-      );
-
-      EMError.hasErrorFromResult(result);
-    } catch (e) {
-      rethrow;
-    }
-  }
-
-  /// ~english
-  /// Gets conversations from the server by conversation filter options.
-  ///
-  /// Param [options] The conversation filter options. See [ConversationFetchOptions].
-  /// Returns The list of retrieved conversations.
-  /// Throws A description of the exception. See [EMError].
-  /// ~end
-  /// ~chinese
-  /// 根据会话过滤选项获取服务端的会话。
-  /// Param [options] 会话过滤选项, 详见 [ConversationFetchOptions]。
-  /// Returns 会话列表。
-  /// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-  /// ~end
-
-  Future<EMCursorResult<EMConversation>> fetchConversationsByOptions({
-    required ConversationFetchOptions options,
-  }) async {
-    try {
-      Map req = options.toJson();
-      Map result = await Client.instance.chatManager
-          .callNativeMethod(ChatMethodKeys.fetchConversationsByOptions, req);
-      EMError.hasErrorFromResult(result);
-      return EMCursorResult<EMConversation>.fromJson(
-          result[ChatMethodKeys.fetchConversationsByOptions],
-          dataItemCallback: (value) {
-        return EMConversation.fromJson(value);
-      });
-    } catch (e) {
-      rethrow;
-    }
-  }
-
-  /// ~english
-  /// Clears all conversations and all messages in them.
-  /// Param [clearServerData] Whether to clear all conversations and all messages in them on the server.
-  /// - true: Yes. All conversations and all messages in them will be cleared on the server side.
-  ///   The current user cannot retrieve messages and conversations from the server, while this has no impact on other users.
-  /// - (Default) false：No. All local conversations and all messages in them will be cleared, while those on the server remain.
-  /// ~end
-  ///
-  /// ~chinese
-  /// 清空所有会话和会话中的所有消息。
-  /// Param [clearServerData] 是否删除服务端所有会话及其消息：
-  /// - true: 是。服务端的所有会话及其消息会被清除，当前用户无法再从服务端拉取消息和会话，其他用户不受影响。
-  /// - （默认）false: 否。只清除本地所有会话及其消息，服务端的会话及其消息仍保留。
-  /// ~end
-
-  Future<void> deleteAllMessageAndConversation(
-      {bool clearServerData = false}) async {
-    try {
-      Map result = await Client.instance.chatManager
-          .callNativeMethod(ChatMethodKeys.deleteAllMessageAndConversation, {
-        'clearServerData': clearServerData,
-      });
-      EMError.hasErrorFromResult(result);
-    } catch (e) {
-      rethrow;
-    }
-  }
-
-  /// ~english
-  /// Pins a message.
-  /// Param [messageId] The message ID.
-  ///
-  /// Throws A description of the exception. See [EMError].
-  /// ~end
-  ///
-  /// ~chinese
-  /// 置顶消息。
-  /// Param [messageId] 消息 ID。
-  ///
-  /// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-  /// ~end
-
-  Future<void> pinMessage({required String messageId}) async {
-    try {
-      Map map = {'msgId': messageId};
-      Map result = await Client.instance.chatManager.callNativeMethod(
-        ChatMethodKeys.pinMessage,
-        map,
-      );
-      EMError.hasErrorFromResult(result);
-    } catch (e) {
-      rethrow;
-    }
-  }
-
-  /// ~english
-  /// Unpins a message.
-  ///
-  /// Param [messageId] The message ID.
-  ///
-  /// Throws A description of the exception. See [EMError].
-  /// ~end
-  /// ~chinese
-  /// 取消置顶消息。
-  ///
-  /// Param [messageId] 消息 ID。
-  ///
-  /// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-  /// ~end
-
-  Future<void> unpinMessage({required String messageId}) async {
-    try {
-      Map map = {'msgId': messageId};
-      Map result = await Client.instance.chatManager.callNativeMethod(
-        ChatMethodKeys.unpinMessage,
-        map,
-      );
-      EMError.hasErrorFromResult(result);
-    } catch (e) {
-      rethrow;
-    }
-  }
-
-  /// ~english
-  /// Gets the list of pinned messages from the server.
-  ///
-  /// Param [conversationId] The conversation ID.
-  /// Returns The list of pinned messages.
-  /// Throws A description of the exception. See [EMError].
-  /// ~end
-  /// ~chinese
-  /// 从服务端获取置顶消息。
-  ///
-  /// Param [conversationId] 会话 ID。
-  /// Returns 置顶消息列表。
-  /// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-  /// ~end
-
-  Future<List<EMMessage>> fetchPinnedMessages(
-      {required String conversationId}) async {
-    try {
-      Map map = {'convId': conversationId};
-      Map result = await Client.instance.chatManager.callNativeMethod(
-        ChatMethodKeys.fetchPinnedMessages,
-        map,
-      );
-      EMError.hasErrorFromResult(result);
-      List<EMMessage> messages = [];
-      List list = result[ChatMethodKeys.fetchPinnedMessages];
-      for (var element in list) {
-        messages.add(EMMessage.fromJson(element));
-      }
-      return messages;
-    } catch (e) {
-      rethrow;
-    }
-  }
+}
 
 // 481
 
-  /// ~english
-  /// Loads messages with the specified keyword from the local database.
-  ///
-  /// Param [options]  search options, see [MessageSearchOptions].
-  ///
-  /// **Returns** The list of retrieved messages.
-  ///
-  /// **Throws** A description of the exception. See [EMError].
-  /// ~end
-  ///
-  /// ~chinese
-  /// 通过类型从数据库获取消息。
-  ///
-  /// Param [options] 搜索配置项, 详情查看 [MessageSearchOptions].
-  ///
-  /// **Return** 消息列表。
-  ///
-  /// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-  /// ~end
+/// ~english
+/// Loads messages with the specified keyword from the local database.
+///
+/// Param [options]  search options, see [MessageSearchOptions].
+///
+/// **Returns** The list of retrieved messages.
+///
+/// **Throws** A description of the exception. See [EMError].
+/// ~end
+///
+/// ~chinese
+/// 通过类型从数据库获取消息。
+///
+/// Param [options] 搜索配置项, 详情查看 [MessageSearchOptions].
+///
+/// **Return** 消息列表。
+///
+/// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+/// ~end
 
-  Future<List<EMMessage>> searchMsgsByOptions(
-      MessageSearchOptions options) async {
-    try {
-      Map req = {};
-      req['ts'] = options.ts;
-      req['count'] = options.count;
-      req['direction'] = options.direction.index;
-      req.putIfNotNull("from", options.from);
-      req['types'] = options.types.map((e) => e.index).toList();
-      Map result = await Client.instance.chatManager
-          .callNativeMethod(ChatMethodKeys.searchMsgsByOptions, req);
-      EMError.hasErrorFromResult(result);
-      List<EMMessage> messages = [];
-      List list = result[ChatMethodKeys.searchMsgsByOptions];
-      for (var element in list) {
-        messages.add(EMMessage.fromJson(element));
-      }
-      return messages;
-    } catch (e) {
-      rethrow;
+Future<List<EMMessage>> searchMsgsByOptions(
+    MessageSearchOptions options) async {
+  try {
+    Map req = {};
+    req['ts'] = options.ts;
+    req['count'] = options.count;
+    req['direction'] = options.direction.index;
+    req.putIfNotNull("from", options.from);
+    req['types'] = options.types.map((e) => e.index).toList();
+    Map result = await Client.instance.chatManager
+        .callNativeMethod(ChatMethodKeys.searchMsgsByOptions, req);
+    EMError.hasErrorFromResult(result);
+    List<EMMessage> messages = [];
+    List list = result[ChatMethodKeys.searchMsgsByOptions];
+    for (var element in list) {
+      messages.add(EMMessage.fromJson(element));
     }
+    return messages;
+  } catch (e) {
+    rethrow;
   }
+}
 
-  /// ~english
-  /// Get the message count from db.
-  ///
-  /// **Returns** The message count in db.
-  ///
-  /// **Throws** A description of the exception. See [EMError].
-  /// ~end
-  ///
-  /// ~chinese
-  /// 获取数据库中的消息总数。
-  ///
-  /// **Return** 数据库中的消息总数。
-  ///
-  /// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError].
-  /// ~end
-  Future<int> getAllMessageCount() async {
-    try {
-      Map result = await Client.instance.chatManager
-          .callNativeMethod(ChatMethodKeys.getMessageCount);
-      EMError.hasErrorFromResult(result);
-      if (result.containsKey(ChatMethodKeys.getMessageCount)) {
-        return result[ChatMethodKeys.getMessageCount];
-      } else {
-        return 0;
-      }
-    } catch (e) {
-      rethrow;
-    }
-  }
 
-  /// ~english
-  /// Loads messages with the specified keyword from the local database,
-  /// returning a map containing conversation IDs and message ID arrays.
-  ///
-  /// Param [keyword]      The search keyword, nil means ignore.
-  /// Param [timestamp]    The starting Unix timestamp in milliseconds.
-  ///                      Negative means fetch from the latest message.
-  /// Param [sender]       The message sender, nil means ignore.
-  /// Param [direction]    Message search direction, see [EMSearchDirection].
-  ///                      - Up: Reverse order by timestamp.
-  ///                      - Down: Chronological order by timestamp.
-  /// Param [scope]        Message search scope, see [MessageSearchScope].
-  ///
-  /// **Returns** A map where key is conversation ID, value is message ID list.
-  ///
-  /// **Throws** Exception description, see [EMError].
-  /// ~end
-  ///
-  /// ~chinese
-  /// 通过关键词从本地数据库中获取消息，返回包含会话 ID 与消息 ID 数组的 Map。
-  /// SDK 按时间顺序返回消息。
-  ///
-  /// Param [keyword]      搜索关键词，nil 表示忽略该参数。
-  /// Param [timestamp]    搜索起始 Unix 时间戳，单位毫秒。
-  ///                     为负数时从最新消息向前获取。
-  /// Param [sender]       消息发送方，nil 表示忽略该参数。
-  /// Param [direction]    消息搜索方向，详见 [EMSearchDirection]。
-  ///                     - Up：按时间戳逆序获取。
-  ///                     - Down：按时间戳顺序获取。
-  /// Param [scope]        消息搜索范围，详见 [MessageSearchScope]。
-  ///
-  /// **Return**  Map，key 为会话 ID，value 为消息 ID 列表。
-  ///
-  /// **Throws** 异常描述，详见 [EMError]。
-  /// ~end
-  Future<Map<String, List<String>>> loadConversationMessagesWithKeyword({
-    String? keyword,
-    int timestamp = -1,
-    String? sender,
-    EMSearchDirection direction = EMSearchDirection.Up,
-    MessageSearchScope scope = MessageSearchScope.All,
-  }) async {
-    try {
-      Map req = {};
-      req.putIfNotNull("keyword", keyword);
-      req["timestamp"] = timestamp;
-      req.putIfNotNull("sender", sender);
-      req["direction"] = direction.index;
-      req["scope"] = scope.index;
-      Map result = await Client.instance.chatManager.callNativeMethod(
-          ChatMethodKeys.loadConversationMessagesWithKeyword, req);
-      EMError.hasErrorFromResult(result);
-      Map<String, List<String>> resultMap = {};
-      Map? data = result[ChatMethodKeys.loadConversationMessagesWithKeyword];
-      if (data != null) {
-        data.forEach((key, value) {
-          resultMap[key] = List<String>.from(value);
-        });
-      }
-      return resultMap;
-    } catch (e) {
-      rethrow;
+/// ~english
+/// Get the message count from db.
+///
+/// **Returns** The message count in db.
+///
+/// **Throws** A description of the exception. See [EMError].
+/// ~end
+///
+/// ~chinese
+/// 获取数据库中的消息总数。
+///
+/// **Return** 数据库中的消息总数。
+///
+/// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError].
+/// ~end
+Future<int> getAllMessageCount() async {
+  try {
+    Map result = await Client.instance.chatManager
+        .callNativeMethod(ChatMethodKeys.getMessageCount);
+    EMError.hasErrorFromResult(result);
+    if (result.containsKey(ChatMethodKeys.getMessageCount)) {
+      return result[ChatMethodKeys.getMessageCount];
+    } else {
+      return 0;
     }
+  } catch (e) {
+    rethrow;
   }
+}
+
+/// ~english
+/// Loads messages with the specified keyword from the local database,
+/// returning a map containing conversation IDs and message ID arrays.
+///
+/// Param [keyword]      The search keyword, nil means ignore.
+/// Param [timestamp]    The starting Unix timestamp in milliseconds.
+///                      Negative means fetch from the latest message.
+/// Param [sender]       The message sender, nil means ignore.
+/// Param [direction]    Message search direction, see [EMSearchDirection].
+///                      - Up: Reverse order by timestamp.
+///                      - Down: Chronological order by timestamp.
+/// Param [scope]        Message search scope, see [MessageSearchScope].
+///
+/// **Returns** A map where key is conversation ID, value is message ID list.
+///
+/// **Throws** Exception description, see [EMError].
+/// ~end
+///
+/// ~chinese
+/// 通过关键词从本地数据库中获取消息，返回包含会话 ID 与消息 ID 数组的 Map。
+/// SDK 按时间顺序返回消息。
+///
+/// Param [keyword]      搜索关键词，nil 表示忽略该参数。
+/// Param [timestamp]    搜索起始 Unix 时间戳，单位毫秒。
+///                     为负数时从最新消息向前获取。
+/// Param [sender]       消息发送方，nil 表示忽略该参数。
+/// Param [direction]    消息搜索方向，详见 [EMSearchDirection]。
+///                     - Up：按时间戳逆序获取。
+///                     - Down：按时间戳顺序获取。
+/// Param [scope]        消息搜索范围，详见 [MessageSearchScope]。
+///
+/// **Return**  Map，key 为会话 ID，value 为消息 ID 列表。
+///
+/// **Throws** 异常描述，详见 [EMError]。
+/// ~end
+Future<Map<String, List<String>>> loadConversationMessagesWithKeyword({
+  String? keyword,
+  int timestamp = -1,
+  String? sender,
+  EMSearchDirection direction = EMSearchDirection.Up,
+  MessageSearchScope scope = MessageSearchScope.All,
+}) async {
+  try {
+    Map req = {};
+    req.putIfNotNull("keyword", keyword);
+    req["timestamp"] = timestamp;
+    req.putIfNotNull("sender", sender);
+    req["direction"] = direction.index;
+    req["scope"] = scope.index;
+    Map result = await Client.instance.chatManager.callNativeMethod(
+        ChatMethodKeys.loadConversationMessagesWithKeyword, req);
+    EMError.hasErrorFromResult(result);
+    Map<String, List<String>> resultMap = {};
+    Map? data = result[ChatMethodKeys.loadConversationMessagesWithKeyword];
+    if (data != null) {
+      data.forEach((key, value) {
+        resultMap[key] = List<String>.from(value);
+      });
+    }
+    return resultMap;
+  } catch (e) {
+    rethrow;
+  }
+}
 }
 
 class MessageCallBackManager {

--- a/im_flutter_sdk/lib/src/managers/chat_manager.dart
+++ b/im_flutter_sdk/lib/src/managers/chat_manager.dart
@@ -1922,611 +1922,609 @@ class EMChatManager {
     }
   }
 
+  /// ~english
+  /// Gets all languages supported by the translation service.
+  ///
+  /// **Return** The supported languages.
+  ///
+  /// **Throws** A description of the exception. See [EMError].
+  /// ~end
+  ///
+  /// ~chinese
+  /// 查询翻译服务支持的语言。
+  ///
+  /// **Return** 翻译服务支持的语言列表。
+  ///
+  /// **Throws** 如果有异常会在此抛出，包括错误码和错误信息，详见 [EMError]。
+  /// ~end
 
-/// ~english
-/// Gets all languages supported by the translation service.
-///
-/// **Return** The supported languages.
-///
-/// **Throws** A description of the exception. See [EMError].
-/// ~end
-///
-/// ~chinese
-/// 查询翻译服务支持的语言。
-///
-/// **Return** 翻译服务支持的语言列表。
-///
-/// **Throws** 如果有异常会在此抛出，包括错误码和错误信息，详见 [EMError]。
-/// ~end
-
-Future<List<EMTranslateLanguage>> fetchSupportedLanguages() async {
-  try {
-    Map result = await Client.instance.chatManager
-        .callNativeMethod(ChatMethodKeys.fetchSupportLanguages);
-    EMError.hasErrorFromResult(result);
-    List<EMTranslateLanguage> list = [];
-    result[ChatMethodKeys.fetchSupportLanguages]?.forEach((element) {
-      list.add(EMTranslateLanguage.fromJson(element));
-    });
-    return list;
-  } catch (e) {
-    rethrow;
-  }
-}
-
-@Deprecated('Use [fetchConversationsByOptions] instead')
-
-/// ~english
-/// Gets the list of pinned conversations from the server with pagination.
-///
-/// The SDK returns the pinned conversations in the reverse chronological order of their pinning.
-///
-/// Param [cursor] The position from which to start getting data. If this parameter is not set, the SDK retrieves conversations from the latest pinned one.
-///
-/// Param [pageSize] The number of conversations that you expect to get on each page. The value range is [1,50].
-///
-/// **Return** The pinned conversation list of the current user.
-///
-/// **Throws** A description of the exception. See [EMError].
-/// ~end
-///
-/// ~chinese
-/// 分页从服务器获取置顶会话。
-///
-/// SDK 按照会话的置顶时间的倒序返回会话列表。
-///
-/// Param [cursor] 查询的开始位置，如不传， SDK 从最新置顶的会话开始查询。
-///
-/// Param [pageSize] 每页期望返回的会话数量。取值范围为 [1,50]。
-///
-/// **Return** 当前用户的置顶会话列表。
-///
-/// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-/// ~end
-Future<EMCursorResult<EMConversation>> fetchPinnedConversations({
-  String? cursor,
-  int pageSize = 20,
-}) async {
-  try {
-    Map map = {
-      "pageSize": pageSize,
-    };
-    map.putIfNotNull('cursor', cursor);
-    Map result = await Client.instance.chatManager.callNativeMethod(
-      ChatMethodKeys.getPinnedConversationsFromServerWithCursor,
-      map,
-    );
-    EMError.hasErrorFromResult(result);
-    return EMCursorResult.fromJson(
-        result[ChatMethodKeys.getPinnedConversationsFromServerWithCursor],
-        dataItemCallback: (map) {
-      return EMConversation.fromJson(map);
-    });
-  } catch (e) {
-    rethrow;
-  }
-}
-
-/// ~english
-/// Sets whether to pin a conversation.
-///
-/// Param [conversationId] The conversation ID.
-///
-/// Param [isPinned]  Whether to pin a conversation:
-/// - true: Pin the conversation.
-/// - false: Unpin the conversation.
-///
-/// **Throws** A description of the exception. See [EMError].
-/// ~end
-///
-/// ~chinese
-/// 设置是否置顶会话。
-///
-/// Param [conversationId] 会话 ID。
-///
-/// Param [isPinned] 是否置顶会话：
-/// - true: 置顶会话。
-/// - false: 取消置顶会话。
-///
-/// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-/// ~end
-
-Future<void> pinConversation(
-    {required String conversationId, required bool isPinned}) async {
-  try {
-    Map map = {
-      'convId': conversationId,
-      'isPinned': isPinned,
-    };
-
-    Map result = await Client.instance.chatManager.callNativeMethod(
-      ChatMethodKeys.pinConversation,
-      map,
-    );
-    EMError.hasErrorFromResult(result);
-  } catch (e) {
-    rethrow;
-  }
-}
-
-/// ~english
-/// Modifies a message.
-///
-/// After this method is called to modify a message, both the local message and the message on the server are modified.
-///
-/// This method can only modify a text message in one-to-one chats or group chats, but not in chat rooms.
-///
-/// Param [messageId] The ID of the message to modify.
-///
-/// Param [msgBody]  The modified message body [EMMessageBody], only [EMTextMessageBody] and [EMCustomMessageBody] are supported.
-///
-/// Param [attributes] The custom attributes of the message.
-///
-/// **Return** The modified message.
-///
-/// **Throws** A description of the exception. See [EMError].
-/// ~end
-///
-/// ~chinese
-/// 修改消息内容。
-///
-/// 调用该方法修改消息内容后，本地和服务端的消息均会修改。
-///
-/// 只能调用该方法修改单聊和群聊中的文本消息，不能修改聊天室消息。
-///
-/// Param [messageId] 消息实例 ID。
-///
-/// Param [msgBody] 息体实例 [EMMessageBody], 只支持 [EMTextMessageBody], [EMCustomMessageBody]。
-///
-/// Param [attributes] 消息的扩展字段
-///
-/// **Return** 修改后的消息实例。
-///
-/// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-/// ~end
-
-Future<EMMessage> modifyMessage({
-  required String messageId,
-  EMMessageBody? msgBody,
-  Map<String, dynamic>? attributes,
-}) async {
-  try {
-    Map map = {'msgId': messageId};
-    map.putIfNotNull('msgBody', msgBody?.toJson());
-    map.putIfNotNull('attributes', attributes);
-
-    Map result = await Client.instance.chatManager.callNativeMethod(
-      ChatMethodKeys.modifyMessage,
-      map,
-    );
-    EMError.hasErrorFromResult(result);
-    return EMMessage.fromJson(result[ChatMethodKeys.modifyMessage]);
-  } catch (e) {
-    rethrow;
-  }
-}
-
-/// ~english
-/// Gets the details of a combined message.
-///
-/// Param [message] The combined message.
-///
-/// **Return** The list of original messages included in the combined message.
-///
-/// **Throws** A description of the exception. See [EMError].
-/// ~end
-///
-/// ~chinese
-/// 获取合并消息的详情。
-///
-/// Param [message] 合并消息。
-///
-/// **Return** 合并消息包含的原始消息列表。
-///
-/// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-/// ~end
-
-Future<List<EMMessage>> fetchCombineMessageDetail({
-  required EMMessage message,
-}) async {
-  try {
-    Map map = {
-      'message': message.toJson(),
-    };
-
-    Map result = await Client.instance.chatManager.callNativeMethod(
-      ChatMethodKeys.downloadAndParseCombineMessage,
-      map,
-    );
-
-    EMError.hasErrorFromResult(result);
-    List<EMMessage> messages = [];
-    List list = result[ChatMethodKeys.downloadAndParseCombineMessage];
-    for (var element in list) {
-      messages.add(EMMessage.fromJson(element));
+  Future<List<EMTranslateLanguage>> fetchSupportedLanguages() async {
+    try {
+      Map result = await Client.instance.chatManager
+          .callNativeMethod(ChatMethodKeys.fetchSupportLanguages);
+      EMError.hasErrorFromResult(result);
+      List<EMTranslateLanguage> list = [];
+      result[ChatMethodKeys.fetchSupportLanguages]?.forEach((element) {
+        list.add(EMTranslateLanguage.fromJson(element));
+      });
+      return list;
+    } catch (e) {
+      rethrow;
     }
-    return messages;
-  } catch (e) {
-    rethrow;
   }
-}
 
-///
-/// ~english
-/// Marks conversations.
-///
-/// This method marks conversations both locally and on the server.
-///
-/// Param [conversationIds] The list of conversation IDs to mark.
-///
-/// Param [mark] The mark to add for the conversations. See [ConversationMarkType].
-///
-/// **Throws** A description of the exception. See [EMError].
-///
-/// ~end
-///
-/// ~chinese
-/// 标记会话。
-///
-/// 调用该方法会同时为本地和服务器端的会话添加标记。
-///
-/// Param [conversationIds] 要标记的会话 ID 列表。
-///
-/// Param [mark] 要添加的会话标记，详见 [ConversationMarkType]。
-///
-/// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-///
-/// ~end
+  @Deprecated('Use [fetchConversationsByOptions] instead')
 
-Future<void> addRemoteAndLocalConversationsMark({
-  required List<String> conversationIds,
-  required ConversationMarkType mark,
-}) async {
-  try {
-    Map map = {
-      'convIds': conversationIds,
-      'mark': mark.index,
-    };
-
-    Map result = await Client.instance.chatManager.callNativeMethod(
-      ChatMethodKeys.addRemoteAndLocalConversationsMark,
-      map,
-    );
-    EMError.hasErrorFromResult(result);
-  } catch (e) {
-    rethrow;
-  }
-}
-
-/// ~english
-/// Unmarks conversations.
-///
-/// This method unmarks conversations both locally and on the server.
-///
-/// Param [conversationIds] The list of conversation IDs to unmark.
-/// Param [mark] The conversation mark to remove. See [ConversationMarkType].
-/// ~end
-///
-/// ~chinese
-/// 取消标记会话。
-///
-/// 本地和服务端取消标记会话。
-///
-/// Param [conversationIds] 要取消标记的会话 ID 列表。
-/// Param [mark] 要移除的会话标记，详见 [ConversationMarkType]。
-/// ~end
-
-Future<void> deleteRemoteAndLocalConversationsMark({
-  required List<String> conversationIds,
-  required ConversationMarkType mark,
-}) async {
-  try {
-    Map map = {
-      'convIds': conversationIds,
-      'mark': mark.index,
-    };
-
-    Map result = await Client.instance.chatManager.callNativeMethod(
-      ChatMethodKeys.deleteRemoteAndLocalConversationsMark,
-      map,
-    );
-
-    EMError.hasErrorFromResult(result);
-  } catch (e) {
-    rethrow;
-  }
-}
-
-/// ~english
-/// Gets conversations from the server by conversation filter options.
-///
-/// Param [options] The conversation filter options. See [ConversationFetchOptions].
-/// Returns The list of retrieved conversations.
-/// Throws A description of the exception. See [EMError].
-/// ~end
-/// ~chinese
-/// 根据会话过滤选项获取服务端的会话。
-/// Param [options] 会话过滤选项, 详见 [ConversationFetchOptions]。
-/// Returns 会话列表。
-/// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-/// ~end
-
-Future<EMCursorResult<EMConversation>> fetchConversationsByOptions({
-  required ConversationFetchOptions options,
-}) async {
-  try {
-    Map req = options.toJson();
-    Map result = await Client.instance.chatManager
-        .callNativeMethod(ChatMethodKeys.fetchConversationsByOptions, req);
-    EMError.hasErrorFromResult(result);
-    return EMCursorResult<EMConversation>.fromJson(
-        result[ChatMethodKeys.fetchConversationsByOptions],
-        dataItemCallback: (value) {
-      return EMConversation.fromJson(value);
-    });
-  } catch (e) {
-    rethrow;
-  }
-}
-
-/// ~english
-/// Clears all conversations and all messages in them.
-/// Param [clearServerData] Whether to clear all conversations and all messages in them on the server.
-/// - true: Yes. All conversations and all messages in them will be cleared on the server side.
-///   The current user cannot retrieve messages and conversations from the server, while this has no impact on other users.
-/// - (Default) false：No. All local conversations and all messages in them will be cleared, while those on the server remain.
-/// ~end
-///
-/// ~chinese
-/// 清空所有会话和会话中的所有消息。
-/// Param [clearServerData] 是否删除服务端所有会话及其消息：
-/// - true: 是。服务端的所有会话及其消息会被清除，当前用户无法再从服务端拉取消息和会话，其他用户不受影响。
-/// - （默认）false: 否。只清除本地所有会话及其消息，服务端的会话及其消息仍保留。
-/// ~end
-
-Future<void> deleteAllMessageAndConversation(
-    {bool clearServerData = false}) async {
-  try {
-    Map result = await Client.instance.chatManager
-        .callNativeMethod(ChatMethodKeys.deleteAllMessageAndConversation, {
-      'clearServerData': clearServerData,
-    });
-    EMError.hasErrorFromResult(result);
-  } catch (e) {
-    rethrow;
-  }
-}
-
-/// ~english
-/// Pins a message.
-/// Param [messageId] The message ID.
-///
-/// Throws A description of the exception. See [EMError].
-/// ~end
-///
-/// ~chinese
-/// 置顶消息。
-/// Param [messageId] 消息 ID。
-///
-/// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-/// ~end
-
-Future<void> pinMessage({required String messageId}) async {
-  try {
-    Map map = {'msgId': messageId};
-    Map result = await Client.instance.chatManager.callNativeMethod(
-      ChatMethodKeys.pinMessage,
-      map,
-    );
-    EMError.hasErrorFromResult(result);
-  } catch (e) {
-    rethrow;
-  }
-}
-
-/// ~english
-/// Unpins a message.
-///
-/// Param [messageId] The message ID.
-///
-/// Throws A description of the exception. See [EMError].
-/// ~end
-/// ~chinese
-/// 取消置顶消息。
-///
-/// Param [messageId] 消息 ID。
-///
-/// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-/// ~end
-
-Future<void> unpinMessage({required String messageId}) async {
-  try {
-    Map map = {'msgId': messageId};
-    Map result = await Client.instance.chatManager.callNativeMethod(
-      ChatMethodKeys.unpinMessage,
-      map,
-    );
-    EMError.hasErrorFromResult(result);
-  } catch (e) {
-    rethrow;
-  }
-}
-
-/// ~english
-/// Gets the list of pinned messages from the server.
-///
-/// Param [conversationId] The conversation ID.
-/// Returns The list of pinned messages.
-/// Throws A description of the exception. See [EMError].
-/// ~end
-/// ~chinese
-/// 从服务端获取置顶消息。
-///
-/// Param [conversationId] 会话 ID。
-/// Returns 置顶消息列表。
-/// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-/// ~end
-
-Future<List<EMMessage>> fetchPinnedMessages(
-    {required String conversationId}) async {
-  try {
-    Map map = {'convId': conversationId};
-    Map result = await Client.instance.chatManager.callNativeMethod(
-      ChatMethodKeys.fetchPinnedMessages,
-      map,
-    );
-    EMError.hasErrorFromResult(result);
-    List<EMMessage> messages = [];
-    List list = result[ChatMethodKeys.fetchPinnedMessages];
-    for (var element in list) {
-      messages.add(EMMessage.fromJson(element));
+  /// ~english
+  /// Gets the list of pinned conversations from the server with pagination.
+  ///
+  /// The SDK returns the pinned conversations in the reverse chronological order of their pinning.
+  ///
+  /// Param [cursor] The position from which to start getting data. If this parameter is not set, the SDK retrieves conversations from the latest pinned one.
+  ///
+  /// Param [pageSize] The number of conversations that you expect to get on each page. The value range is [1,50].
+  ///
+  /// **Return** The pinned conversation list of the current user.
+  ///
+  /// **Throws** A description of the exception. See [EMError].
+  /// ~end
+  ///
+  /// ~chinese
+  /// 分页从服务器获取置顶会话。
+  ///
+  /// SDK 按照会话的置顶时间的倒序返回会话列表。
+  ///
+  /// Param [cursor] 查询的开始位置，如不传， SDK 从最新置顶的会话开始查询。
+  ///
+  /// Param [pageSize] 每页期望返回的会话数量。取值范围为 [1,50]。
+  ///
+  /// **Return** 当前用户的置顶会话列表。
+  ///
+  /// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+  /// ~end
+  Future<EMCursorResult<EMConversation>> fetchPinnedConversations({
+    String? cursor,
+    int pageSize = 20,
+  }) async {
+    try {
+      Map map = {
+        "pageSize": pageSize,
+      };
+      map.putIfNotNull('cursor', cursor);
+      Map result = await Client.instance.chatManager.callNativeMethod(
+        ChatMethodKeys.getPinnedConversationsFromServerWithCursor,
+        map,
+      );
+      EMError.hasErrorFromResult(result);
+      return EMCursorResult.fromJson(
+          result[ChatMethodKeys.getPinnedConversationsFromServerWithCursor],
+          dataItemCallback: (map) {
+        return EMConversation.fromJson(map);
+      });
+    } catch (e) {
+      rethrow;
     }
-    return messages;
-  } catch (e) {
-    rethrow;
   }
-}
+
+  /// ~english
+  /// Sets whether to pin a conversation.
+  ///
+  /// Param [conversationId] The conversation ID.
+  ///
+  /// Param [isPinned]  Whether to pin a conversation:
+  /// - true: Pin the conversation.
+  /// - false: Unpin the conversation.
+  ///
+  /// **Throws** A description of the exception. See [EMError].
+  /// ~end
+  ///
+  /// ~chinese
+  /// 设置是否置顶会话。
+  ///
+  /// Param [conversationId] 会话 ID。
+  ///
+  /// Param [isPinned] 是否置顶会话：
+  /// - true: 置顶会话。
+  /// - false: 取消置顶会话。
+  ///
+  /// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+  /// ~end
+
+  Future<void> pinConversation(
+      {required String conversationId, required bool isPinned}) async {
+    try {
+      Map map = {
+        'convId': conversationId,
+        'isPinned': isPinned,
+      };
+
+      Map result = await Client.instance.chatManager.callNativeMethod(
+        ChatMethodKeys.pinConversation,
+        map,
+      );
+      EMError.hasErrorFromResult(result);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  /// ~english
+  /// Modifies a message.
+  ///
+  /// After this method is called to modify a message, both the local message and the message on the server are modified.
+  ///
+  /// This method can only modify a text message in one-to-one chats or group chats, but not in chat rooms.
+  ///
+  /// Param [messageId] The ID of the message to modify.
+  ///
+  /// Param [msgBody]  The modified message body [EMMessageBody], only [EMTextMessageBody] and [EMCustomMessageBody] are supported.
+  ///
+  /// Param [attributes] The custom attributes of the message.
+  ///
+  /// **Return** The modified message.
+  ///
+  /// **Throws** A description of the exception. See [EMError].
+  /// ~end
+  ///
+  /// ~chinese
+  /// 修改消息内容。
+  ///
+  /// 调用该方法修改消息内容后，本地和服务端的消息均会修改。
+  ///
+  /// 只能调用该方法修改单聊和群聊中的文本消息，不能修改聊天室消息。
+  ///
+  /// Param [messageId] 消息实例 ID。
+  ///
+  /// Param [msgBody] 息体实例 [EMMessageBody], 只支持 [EMTextMessageBody], [EMCustomMessageBody]。
+  ///
+  /// Param [attributes] 消息的扩展字段
+  ///
+  /// **Return** 修改后的消息实例。
+  ///
+  /// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+  /// ~end
+
+  Future<EMMessage> modifyMessage({
+    required String messageId,
+    EMMessageBody? msgBody,
+    Map<String, dynamic>? attributes,
+  }) async {
+    try {
+      Map map = {'msgId': messageId};
+      map.putIfNotNull('msgBody', msgBody?.toJson());
+      map.putIfNotNull('attributes', attributes);
+
+      Map result = await Client.instance.chatManager.callNativeMethod(
+        ChatMethodKeys.modifyMessage,
+        map,
+      );
+      EMError.hasErrorFromResult(result);
+      return EMMessage.fromJson(result[ChatMethodKeys.modifyMessage]);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  /// ~english
+  /// Gets the details of a combined message.
+  ///
+  /// Param [message] The combined message.
+  ///
+  /// **Return** The list of original messages included in the combined message.
+  ///
+  /// **Throws** A description of the exception. See [EMError].
+  /// ~end
+  ///
+  /// ~chinese
+  /// 获取合并消息的详情。
+  ///
+  /// Param [message] 合并消息。
+  ///
+  /// **Return** 合并消息包含的原始消息列表。
+  ///
+  /// **Throws**  如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+  /// ~end
+
+  Future<List<EMMessage>> fetchCombineMessageDetail({
+    required EMMessage message,
+  }) async {
+    try {
+      Map map = {
+        'message': message.toJson(),
+      };
+
+      Map result = await Client.instance.chatManager.callNativeMethod(
+        ChatMethodKeys.downloadAndParseCombineMessage,
+        map,
+      );
+
+      EMError.hasErrorFromResult(result);
+      List<EMMessage> messages = [];
+      List list = result[ChatMethodKeys.downloadAndParseCombineMessage];
+      for (var element in list) {
+        messages.add(EMMessage.fromJson(element));
+      }
+      return messages;
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  ///
+  /// ~english
+  /// Marks conversations.
+  ///
+  /// This method marks conversations both locally and on the server.
+  ///
+  /// Param [conversationIds] The list of conversation IDs to mark.
+  ///
+  /// Param [mark] The mark to add for the conversations. See [ConversationMarkType].
+  ///
+  /// **Throws** A description of the exception. See [EMError].
+  ///
+  /// ~end
+  ///
+  /// ~chinese
+  /// 标记会话。
+  ///
+  /// 调用该方法会同时为本地和服务器端的会话添加标记。
+  ///
+  /// Param [conversationIds] 要标记的会话 ID 列表。
+  ///
+  /// Param [mark] 要添加的会话标记，详见 [ConversationMarkType]。
+  ///
+  /// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+  ///
+  /// ~end
+
+  Future<void> addRemoteAndLocalConversationsMark({
+    required List<String> conversationIds,
+    required ConversationMarkType mark,
+  }) async {
+    try {
+      Map map = {
+        'convIds': conversationIds,
+        'mark': mark.index,
+      };
+
+      Map result = await Client.instance.chatManager.callNativeMethod(
+        ChatMethodKeys.addRemoteAndLocalConversationsMark,
+        map,
+      );
+      EMError.hasErrorFromResult(result);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  /// ~english
+  /// Unmarks conversations.
+  ///
+  /// This method unmarks conversations both locally and on the server.
+  ///
+  /// Param [conversationIds] The list of conversation IDs to unmark.
+  /// Param [mark] The conversation mark to remove. See [ConversationMarkType].
+  /// ~end
+  ///
+  /// ~chinese
+  /// 取消标记会话。
+  ///
+  /// 本地和服务端取消标记会话。
+  ///
+  /// Param [conversationIds] 要取消标记的会话 ID 列表。
+  /// Param [mark] 要移除的会话标记，详见 [ConversationMarkType]。
+  /// ~end
+
+  Future<void> deleteRemoteAndLocalConversationsMark({
+    required List<String> conversationIds,
+    required ConversationMarkType mark,
+  }) async {
+    try {
+      Map map = {
+        'convIds': conversationIds,
+        'mark': mark.index,
+      };
+
+      Map result = await Client.instance.chatManager.callNativeMethod(
+        ChatMethodKeys.deleteRemoteAndLocalConversationsMark,
+        map,
+      );
+
+      EMError.hasErrorFromResult(result);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  /// ~english
+  /// Gets conversations from the server by conversation filter options.
+  ///
+  /// Param [options] The conversation filter options. See [ConversationFetchOptions].
+  /// Returns The list of retrieved conversations.
+  /// Throws A description of the exception. See [EMError].
+  /// ~end
+  /// ~chinese
+  /// 根据会话过滤选项获取服务端的会话。
+  /// Param [options] 会话过滤选项, 详见 [ConversationFetchOptions]。
+  /// Returns 会话列表。
+  /// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+  /// ~end
+
+  Future<EMCursorResult<EMConversation>> fetchConversationsByOptions({
+    required ConversationFetchOptions options,
+  }) async {
+    try {
+      Map req = options.toJson();
+      Map result = await Client.instance.chatManager
+          .callNativeMethod(ChatMethodKeys.fetchConversationsByOptions, req);
+      EMError.hasErrorFromResult(result);
+      return EMCursorResult<EMConversation>.fromJson(
+          result[ChatMethodKeys.fetchConversationsByOptions],
+          dataItemCallback: (value) {
+        return EMConversation.fromJson(value);
+      });
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  /// ~english
+  /// Clears all conversations and all messages in them.
+  /// Param [clearServerData] Whether to clear all conversations and all messages in them on the server.
+  /// - true: Yes. All conversations and all messages in them will be cleared on the server side.
+  ///   The current user cannot retrieve messages and conversations from the server, while this has no impact on other users.
+  /// - (Default) false：No. All local conversations and all messages in them will be cleared, while those on the server remain.
+  /// ~end
+  ///
+  /// ~chinese
+  /// 清空所有会话和会话中的所有消息。
+  /// Param [clearServerData] 是否删除服务端所有会话及其消息：
+  /// - true: 是。服务端的所有会话及其消息会被清除，当前用户无法再从服务端拉取消息和会话，其他用户不受影响。
+  /// - （默认）false: 否。只清除本地所有会话及其消息，服务端的会话及其消息仍保留。
+  /// ~end
+
+  Future<void> deleteAllMessageAndConversation(
+      {bool clearServerData = false}) async {
+    try {
+      Map result = await Client.instance.chatManager
+          .callNativeMethod(ChatMethodKeys.deleteAllMessageAndConversation, {
+        'clearServerData': clearServerData,
+      });
+      EMError.hasErrorFromResult(result);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  /// ~english
+  /// Pins a message.
+  /// Param [messageId] The message ID.
+  ///
+  /// Throws A description of the exception. See [EMError].
+  /// ~end
+  ///
+  /// ~chinese
+  /// 置顶消息。
+  /// Param [messageId] 消息 ID。
+  ///
+  /// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+  /// ~end
+
+  Future<void> pinMessage({required String messageId}) async {
+    try {
+      Map map = {'msgId': messageId};
+      Map result = await Client.instance.chatManager.callNativeMethod(
+        ChatMethodKeys.pinMessage,
+        map,
+      );
+      EMError.hasErrorFromResult(result);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  /// ~english
+  /// Unpins a message.
+  ///
+  /// Param [messageId] The message ID.
+  ///
+  /// Throws A description of the exception. See [EMError].
+  /// ~end
+  /// ~chinese
+  /// 取消置顶消息。
+  ///
+  /// Param [messageId] 消息 ID。
+  ///
+  /// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+  /// ~end
+
+  Future<void> unpinMessage({required String messageId}) async {
+    try {
+      Map map = {'msgId': messageId};
+      Map result = await Client.instance.chatManager.callNativeMethod(
+        ChatMethodKeys.unpinMessage,
+        map,
+      );
+      EMError.hasErrorFromResult(result);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  /// ~english
+  /// Gets the list of pinned messages from the server.
+  ///
+  /// Param [conversationId] The conversation ID.
+  /// Returns The list of pinned messages.
+  /// Throws A description of the exception. See [EMError].
+  /// ~end
+  /// ~chinese
+  /// 从服务端获取置顶消息。
+  ///
+  /// Param [conversationId] 会话 ID。
+  /// Returns 置顶消息列表。
+  /// Throws 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+  /// ~end
+
+  Future<List<EMMessage>> fetchPinnedMessages(
+      {required String conversationId}) async {
+    try {
+      Map map = {'convId': conversationId};
+      Map result = await Client.instance.chatManager.callNativeMethod(
+        ChatMethodKeys.fetchPinnedMessages,
+        map,
+      );
+      EMError.hasErrorFromResult(result);
+      List<EMMessage> messages = [];
+      List list = result[ChatMethodKeys.fetchPinnedMessages];
+      for (var element in list) {
+        messages.add(EMMessage.fromJson(element));
+      }
+      return messages;
+    } catch (e) {
+      rethrow;
+    }
+  }
 
 // 481
 
-/// ~english
-/// Loads messages with the specified keyword from the local database.
-///
-/// Param [options]  search options, see [MessageSearchOptions].
-///
-/// **Returns** The list of retrieved messages.
-///
-/// **Throws** A description of the exception. See [EMError].
-/// ~end
-///
-/// ~chinese
-/// 通过类型从数据库获取消息。
-///
-/// Param [options] 搜索配置项, 详情查看 [MessageSearchOptions].
-///
-/// **Return** 消息列表。
-///
-/// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
-/// ~end
+  /// ~english
+  /// Loads messages with the specified keyword from the local database.
+  ///
+  /// Param [options]  search options, see [MessageSearchOptions].
+  ///
+  /// **Returns** The list of retrieved messages.
+  ///
+  /// **Throws** A description of the exception. See [EMError].
+  /// ~end
+  ///
+  /// ~chinese
+  /// 通过类型从数据库获取消息。
+  ///
+  /// Param [options] 搜索配置项, 详情查看 [MessageSearchOptions].
+  ///
+  /// **Return** 消息列表。
+  ///
+  /// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError]。
+  /// ~end
 
-Future<List<EMMessage>> searchMsgsByOptions(
-    MessageSearchOptions options) async {
-  try {
-    Map req = {};
-    req['ts'] = options.ts;
-    req['count'] = options.count;
-    req['direction'] = options.direction.index;
-    req.putIfNotNull("from", options.from);
-    req['types'] = options.types.map((e) => e.index).toList();
-    Map result = await Client.instance.chatManager
-        .callNativeMethod(ChatMethodKeys.searchMsgsByOptions, req);
-    EMError.hasErrorFromResult(result);
-    List<EMMessage> messages = [];
-    List list = result[ChatMethodKeys.searchMsgsByOptions];
-    for (var element in list) {
-      messages.add(EMMessage.fromJson(element));
+  Future<List<EMMessage>> searchMsgsByOptions(
+      MessageSearchOptions options) async {
+    try {
+      Map req = {};
+      req['ts'] = options.ts;
+      req['count'] = options.count;
+      req['direction'] = options.direction.index;
+      req.putIfNotNull("from", options.from);
+      req['types'] = options.types.map((e) => e.index).toList();
+      Map result = await Client.instance.chatManager
+          .callNativeMethod(ChatMethodKeys.searchMsgsByOptions, req);
+      EMError.hasErrorFromResult(result);
+      List<EMMessage> messages = [];
+      List list = result[ChatMethodKeys.searchMsgsByOptions];
+      for (var element in list) {
+        messages.add(EMMessage.fromJson(element));
+      }
+      return messages;
+    } catch (e) {
+      rethrow;
     }
-    return messages;
-  } catch (e) {
-    rethrow;
   }
-}
 
-
-/// ~english
-/// Get the message count from db.
-///
-/// **Returns** The message count in db.
-///
-/// **Throws** A description of the exception. See [EMError].
-/// ~end
-///
-/// ~chinese
-/// 获取数据库中的消息总数。
-///
-/// **Return** 数据库中的消息总数。
-///
-/// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError].
-/// ~end
-Future<int> getAllMessageCount() async {
-  try {
-    Map result = await Client.instance.chatManager
-        .callNativeMethod(ChatMethodKeys.getMessageCount);
-    EMError.hasErrorFromResult(result);
-    if (result.containsKey(ChatMethodKeys.getMessageCount)) {
-      return result[ChatMethodKeys.getMessageCount];
-    } else {
-      return 0;
+  /// ~english
+  /// Get the message count from db.
+  ///
+  /// **Returns** The message count in db.
+  ///
+  /// **Throws** A description of the exception. See [EMError].
+  /// ~end
+  ///
+  /// ~chinese
+  /// 获取数据库中的消息总数。
+  ///
+  /// **Return** 数据库中的消息总数。
+  ///
+  /// **Throws** 如果有异常会在这里抛出，包含错误码和错误描述，详见 [EMError].
+  /// ~end
+  Future<int> getAllMessageCount() async {
+    try {
+      Map result = await Client.instance.chatManager
+          .callNativeMethod(ChatMethodKeys.getMessageCount);
+      EMError.hasErrorFromResult(result);
+      if (result.containsKey(ChatMethodKeys.getMessageCount)) {
+        return result[ChatMethodKeys.getMessageCount];
+      } else {
+        return 0;
+      }
+    } catch (e) {
+      rethrow;
     }
-  } catch (e) {
-    rethrow;
   }
-}
 
-/// ~english
-/// Loads messages with the specified keyword from the local database,
-/// returning a map containing conversation IDs and message ID arrays.
-///
-/// Param [keyword]      The search keyword, nil means ignore.
-/// Param [timestamp]    The starting Unix timestamp in milliseconds.
-///                      Negative means fetch from the latest message.
-/// Param [sender]       The message sender, nil means ignore.
-/// Param [direction]    Message search direction, see [EMSearchDirection].
-///                      - Up: Reverse order by timestamp.
-///                      - Down: Chronological order by timestamp.
-/// Param [scope]        Message search scope, see [MessageSearchScope].
-///
-/// **Returns** A map where key is conversation ID, value is message ID list.
-///
-/// **Throws** Exception description, see [EMError].
-/// ~end
-///
-/// ~chinese
-/// 通过关键词从本地数据库中获取消息，返回包含会话 ID 与消息 ID 数组的 Map。
-/// SDK 按时间顺序返回消息。
-///
-/// Param [keyword]      搜索关键词，nil 表示忽略该参数。
-/// Param [timestamp]    搜索起始 Unix 时间戳，单位毫秒。
-///                     为负数时从最新消息向前获取。
-/// Param [sender]       消息发送方，nil 表示忽略该参数。
-/// Param [direction]    消息搜索方向，详见 [EMSearchDirection]。
-///                     - Up：按时间戳逆序获取。
-///                     - Down：按时间戳顺序获取。
-/// Param [scope]        消息搜索范围，详见 [MessageSearchScope]。
-///
-/// **Return**  Map，key 为会话 ID，value 为消息 ID 列表。
-///
-/// **Throws** 异常描述，详见 [EMError]。
-/// ~end
-Future<Map<String, List<String>>> loadConversationMessagesWithKeyword({
-  String? keyword,
-  int timestamp = -1,
-  String? sender,
-  EMSearchDirection direction = EMSearchDirection.Up,
-  MessageSearchScope scope = MessageSearchScope.All,
-}) async {
-  try {
-    Map req = {};
-    req.putIfNotNull("keyword", keyword);
-    req["timestamp"] = timestamp;
-    req.putIfNotNull("sender", sender);
-    req["direction"] = direction.index;
-    req["scope"] = scope.index;
-    Map result = await Client.instance.chatManager.callNativeMethod(
-        ChatMethodKeys.loadConversationMessagesWithKeyword, req);
-    EMError.hasErrorFromResult(result);
-    Map<String, List<String>> resultMap = {};
-    Map? data = result[ChatMethodKeys.loadConversationMessagesWithKeyword];
-    if (data != null) {
-      data.forEach((key, value) {
-        resultMap[key] = List<String>.from(value);
-      });
+  /// ~english
+  /// Loads messages with the specified keyword from the local database,
+  /// returning a map containing conversation IDs and message ID arrays.
+  ///
+  /// Param [keyword]      The search keyword, nil means ignore.
+  /// Param [timestamp]    The starting Unix timestamp in milliseconds.
+  ///                      Negative means fetch from the latest message.
+  /// Param [sender]       The message sender, nil means ignore.
+  /// Param [direction]    Message search direction, see [EMSearchDirection].
+  ///                      - Up: Reverse order by timestamp.
+  ///                      - Down: Chronological order by timestamp.
+  /// Param [scope]        Message search scope, see [MessageSearchScope].
+  ///
+  /// **Returns** A map where key is conversation ID, value is message ID list.
+  ///
+  /// **Throws** Exception description, see [EMError].
+  /// ~end
+  ///
+  /// ~chinese
+  /// 通过关键词从本地数据库中获取消息，返回包含会话 ID 与消息 ID 数组的 Map。
+  /// SDK 按时间顺序返回消息。
+  ///
+  /// Param [keyword]      搜索关键词，nil 表示忽略该参数。
+  /// Param [timestamp]    搜索起始 Unix 时间戳，单位毫秒。
+  ///                     为负数时从最新消息向前获取。
+  /// Param [sender]       消息发送方，nil 表示忽略该参数。
+  /// Param [direction]    消息搜索方向，详见 [EMSearchDirection]。
+  ///                     - Up：按时间戳逆序获取。
+  ///                     - Down：按时间戳顺序获取。
+  /// Param [scope]        消息搜索范围，详见 [MessageSearchScope]。
+  ///
+  /// **Return**  Map，key 为会话 ID，value 为消息 ID 列表。
+  ///
+  /// **Throws** 异常描述，详见 [EMError]。
+  /// ~end
+  Future<Map<String, List<String>>> loadConversationMessagesWithKeyword({
+    String? keyword,
+    int timestamp = -1,
+    String? sender,
+    EMSearchDirection direction = EMSearchDirection.Up,
+    MessageSearchScope scope = MessageSearchScope.All,
+  }) async {
+    try {
+      Map req = {};
+      req.putIfNotNull("keyword", keyword);
+      req["timestamp"] = timestamp;
+      req.putIfNotNull("sender", sender);
+      req["direction"] = direction.index;
+      req["scope"] = scope.index;
+      Map result = await Client.instance.chatManager.callNativeMethod(
+          ChatMethodKeys.loadConversationMessagesWithKeyword, req);
+      EMError.hasErrorFromResult(result);
+      Map<String, List<String>> resultMap = {};
+      Map? data = result[ChatMethodKeys.loadConversationMessagesWithKeyword];
+      if (data != null) {
+        data.forEach((key, value) {
+          resultMap[key] = List<String>.from(value);
+        });
+      }
+      return resultMap;
+    } catch (e) {
+      rethrow;
     }
-    return resultMap;
-  } catch (e) {
-    rethrow;
   }
-}
 }
 
 class MessageCallBackManager {

--- a/im_flutter_sdk/lib/src/managers/chat_room_manager.dart
+++ b/im_flutter_sdk/lib/src/managers/chat_room_manager.dart
@@ -1518,6 +1518,7 @@ class EMChatRoomManager {
     }
   }
 
+
   /// ~english
   /// Checks whether the current user is on the chatroom mute list.
   ///

--- a/im_flutter_sdk/lib/src/managers/chat_room_manager.dart
+++ b/im_flutter_sdk/lib/src/managers/chat_room_manager.dart
@@ -1518,7 +1518,6 @@ class EMChatRoomManager {
     }
   }
 
-
   /// ~english
   /// Checks whether the current user is on the chatroom mute list.
   ///

--- a/im_flutter_sdk/lib/src/managers/client.dart
+++ b/im_flutter_sdk/lib/src/managers/client.dart
@@ -540,7 +540,7 @@ class EMClient {
 
     try {
       _options = options;
-      EMLog.v('init: $options');
+      EMLog.v('init');
       await Client.instance
           .callNativeMethod(ChatMethodKeys.init, options.toJson());
       _currentUserId = await getCurrentUserId();
@@ -573,7 +573,7 @@ class EMClient {
   /// ~end
   Future<void> createAccount(String userId, String password) async {
     try {
-      EMLog.v('create account: $userId : $password');
+      EMLog.v('create account: $userId');
       Map req = {'userId': userId, 'password': password};
       Map result = await Client.instance
           .callNativeMethod(ChatMethodKeys.createAccount, req);
@@ -623,7 +623,7 @@ class EMClient {
     bool isPassword = true,
   ]) async {
     try {
-      EMLog.v('login: $userId : $pwdOrToken, isPassword: $isPassword');
+      EMLog.v('login: $userId, isPassword: $isPassword');
       Map req = {
         'userId': userId,
         'pwdOrToken': pwdOrToken,
@@ -666,7 +666,7 @@ class EMClient {
   /// ~end
   Future<void> loginWithAgoraToken(String userId, String agoraToken) async {
     try {
-      return login(userId, agoraToken, false);
+      return await login(userId, agoraToken, false);
     } catch (e) {
       rethrow;
     }
@@ -704,7 +704,7 @@ class EMClient {
   ) async {
     try {
       // ignore: deprecated_member_use_from_same_package
-      return login(userId, token, false);
+      return await login(userId, token, false);
     } catch (e) {
       rethrow;
     }
@@ -742,7 +742,7 @@ class EMClient {
   ) async {
     try {
       // ignore: deprecated_member_use_from_same_package
-      return login(userId, password, true);
+      return await login(userId, password, true);
     } catch (e) {
       rethrow;
     }
@@ -835,7 +835,7 @@ class EMClient {
   /// ~end
   Future<bool> changeAppKey({required String newAppKey}) async {
     try {
-      EMLog.v('changeAppKey: $newAppKey');
+      EMLog.v('changeAppKey');
       Map req = {'appKey': newAppKey};
       Map result = await Client.instance
           .callNativeMethod(ChatMethodKeys.changeAppKey, req);

--- a/im_flutter_sdk/lib/src/models/em_chat_enums.dart
+++ b/im_flutter_sdk/lib/src/models/em_chat_enums.dart
@@ -1181,8 +1181,6 @@ enum ConversationMarkType {
   Type19,
 }
 
-
-
 extension EMGroupPermissionTypeExtension on EMGroupPermissionType {
   static EMGroupPermissionType values(int type) {
     return EMGroupPermissionType.values[type + 1];

--- a/im_flutter_sdk/lib/src/models/em_chat_enums.dart
+++ b/im_flutter_sdk/lib/src/models/em_chat_enums.dart
@@ -1181,6 +1181,8 @@ enum ConversationMarkType {
   Type19,
 }
 
+
+
 extension EMGroupPermissionTypeExtension on EMGroupPermissionType {
   static EMGroupPermissionType values(int type) {
     return EMGroupPermissionType.values[type + 1];

--- a/im_flutter_sdk/lib/src/models/group_member_info.dart
+++ b/im_flutter_sdk/lib/src/models/group_member_info.dart
@@ -16,6 +16,7 @@ class GroupMemberInfo {
   /// 群成员用户 ID。
   /// ~end
   final String userId;
+
   /// ~english
   /// The timestamp when the user joined the group.
   /// ~end
@@ -24,6 +25,7 @@ class GroupMemberInfo {
   /// 用户加入群组的时间戳。
   /// ~end
   final int joinedTs;
+
   /// ~english
   /// The role of the group member.
   /// ~end
@@ -32,6 +34,7 @@ class GroupMemberInfo {
   /// 群成员角色。
   /// ~end
   final EMGroupPermissionType role;
+
   /// ~english
   /// Creates a group member info.
   /// ~end

--- a/im_flutter_sdk/lib/src/models/group_member_info.dart
+++ b/im_flutter_sdk/lib/src/models/group_member_info.dart
@@ -16,7 +16,6 @@ class GroupMemberInfo {
   /// 群成员用户 ID。
   /// ~end
   final String userId;
-
   /// ~english
   /// The timestamp when the user joined the group.
   /// ~end
@@ -25,7 +24,6 @@ class GroupMemberInfo {
   /// 用户加入群组的时间戳。
   /// ~end
   final int joinedTs;
-
   /// ~english
   /// The role of the group member.
   /// ~end
@@ -34,7 +32,6 @@ class GroupMemberInfo {
   /// 群成员角色。
   /// ~end
   final EMGroupPermissionType role;
-
   /// ~english
   /// Creates a group member info.
   /// ~end

--- a/im_flutter_sdk/pubspec.yaml
+++ b/im_flutter_sdk/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
 
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   flutter_lints: ^4.0.0
 
 

--- a/im_flutter_sdk/test/ci/case_mapping_checker_test.dart
+++ b/im_flutter_sdk/test/ci/case_mapping_checker_test.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/ci/case_mapping_checker.dart';
+
+void main() {
+  late Directory fixture;
+
+  setUp(() {
+    fixture = Directory.systemTemp.createTempSync('flutter-case-mapping-');
+    final testFile = File('${fixture.path}/integration_test/smoke_test.dart');
+    testFile.parent.createSync(recursive: true);
+    testFile
+        .writeAsStringSync("testWidgets('FL-APP-001 initializes', (_) {});");
+  });
+
+  tearDown(() {
+    fixture.deleteSync(recursive: true);
+  });
+
+  void writeMapping(Map<String, Object> item) {
+    final file = File('${fixture.path}/docs/ci/native-case-mapping.json');
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(jsonEncode(<String, Object>{
+      'schemaVersion': 1,
+      'nativeBaseline': 'easemob/im-auto-test@commit',
+      'cases': <Map<String, Object>>[item],
+    }));
+  }
+
+  Map<String, Object> validCase() => <String, Object>{
+        'id': 'FL-APP-001',
+        'priority': 'P0',
+        'origin': 'flutter-only',
+        'sourceCases': <String>[],
+        'flutterApis': <String>['EMClient.init'],
+        'platforms': <String>['android', 'ios'],
+        'assertions': <String>['SDK initialization succeeds'],
+        'testFile': 'integration_test/smoke_test.dart',
+      };
+
+  test('accepts a traceable case whose implementation exists', () {
+    writeMapping(validCase());
+
+    expect(checkCaseMapping(fixture.path), isEmpty);
+  });
+
+  test('requires Native sources for native-shared cases', () {
+    writeMapping(<String, Object>{
+      ...validCase(),
+      'origin': 'native-shared',
+    });
+
+    expect(
+      checkCaseMapping(fixture.path),
+      contains('FL-APP-001: native-shared requires sourceCases'),
+    );
+  });
+
+  test('requires every mapped id to appear in its test file', () {
+    writeMapping(<String, Object>{
+      ...validCase(),
+      'id': 'FL-APP-002',
+    });
+
+    expect(
+      checkCaseMapping(fixture.path),
+      contains(
+        'FL-APP-002: id not found in integration_test/smoke_test.dart',
+      ),
+    );
+  });
+}

--- a/im_flutter_sdk/test/ci/contract_checker_test.dart
+++ b/im_flutter_sdk/test/ci/contract_checker_test.dart
@@ -1,0 +1,175 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/ci/contract_checker.dart';
+
+void main() {
+  group('MethodChannel contract checker', () {
+    late Directory fixture;
+
+    setUp(() {
+      fixture = Directory.systemTemp.createTempSync('flutter-contracts-');
+      _writeFixture(fixture);
+    });
+
+    tearDown(() {
+      fixture.deleteSync(recursive: true);
+    });
+
+    test('accepts matching constants and registered routes', () {
+      expect(checkContracts(fixture.path), isEmpty);
+    });
+
+    test('reports a platform value mismatch with all three values', () {
+      File('${fixture.path}/android/MethodKey.java').writeAsStringSync('''
+public final class MethodKey {
+  public static final String login = "loginV2";
+  public static final String logout = "logout";
+}
+''');
+
+      expect(
+        checkContracts(fixture.path),
+        contains(
+          'Method key mismatch: login '
+          'dart=login android=loginV2 ios=login',
+        ),
+      );
+    });
+
+    test('reports a method missing from an Android route', () {
+      File('${fixture.path}/android/ClientWrapper.java').writeAsStringSync('''
+switch (call.method) {
+  case MethodKey.login:
+    login(call);
+    break;
+}
+''');
+
+      expect(
+        checkContracts(fixture.path),
+        contains('Android route missing: logout'),
+      );
+    });
+
+    test('reports a method missing from an iOS route', () {
+      File('${fixture.path}/ios/ClientWrapper.m').writeAsStringSync('''
+if ([call.method isEqualToString:EMMethodKeyLogin]) {
+  [self login:call];
+}
+''');
+
+      expect(
+        checkContracts(fixture.path),
+        contains('iOS route missing: logout'),
+      );
+    });
+
+    test('matches platform constant names by their wire value', () {
+      File('${fixture.path}/dart/chat_method_keys.dart').writeAsStringSync(
+        "  static const String fetchSupportLanguages = "
+        "'fetchSupportLanguages';\n",
+        mode: FileMode.append,
+      );
+      File('${fixture.path}/dart/client.dart').writeAsStringSync(
+        'channel.callNativeMethod(ChatMethodKeys.fetchSupportLanguages);\n',
+        mode: FileMode.append,
+      );
+      File('${fixture.path}/android/MethodKey.java').writeAsStringSync(
+        'static final String fetchSupportedLanguages = '
+        '"fetchSupportLanguages";\n',
+        mode: FileMode.append,
+      );
+      File('${fixture.path}/android/ClientWrapper.java').writeAsStringSync(
+        'case MethodKey.fetchSupportedLanguages: break;\n',
+        mode: FileMode.append,
+      );
+      File('${fixture.path}/ios/MethodKeys.h').writeAsStringSync(
+        'static NSString *const ChatFetchSupportedLanguages = '
+        '@"fetchSupportLanguages";\n',
+        mode: FileMode.append,
+      );
+      File('${fixture.path}/ios/ClientWrapper.m').writeAsStringSync(
+        'if ([ChatFetchSupportedLanguages isEqualToString:call.method]) {}\n',
+        mode: FileMode.append,
+      );
+
+      expect(checkContracts(fixture.path), isEmpty);
+    });
+
+    test('allows APNs and HMS routes only on their supported platform', () {
+      File('${fixture.path}/dart/chat_method_keys.dart').writeAsStringSync('''
+  static const String updateAPNsPushToken = 'updateAPNsPushToken';
+  static const String updateHMSPushToken = 'updateHMSPushToken';
+''', mode: FileMode.append);
+      File('${fixture.path}/dart/client.dart').writeAsStringSync('''
+channel.callNativeMethod(ChatMethodKeys.updateAPNsPushToken);
+channel.callNativeMethod(ChatMethodKeys.updateHMSPushToken);
+''', mode: FileMode.append);
+      File('${fixture.path}/android/MethodKey.java').writeAsStringSync(
+        'static final String updateHMSPushToken = "updateHMSPushToken";\n',
+        mode: FileMode.append,
+      );
+      File('${fixture.path}/android/ClientWrapper.java').writeAsStringSync(
+        'case MethodKey.updateHMSPushToken: break;\n',
+        mode: FileMode.append,
+      );
+      File('${fixture.path}/ios/MethodKeys.h').writeAsStringSync(
+        'static NSString *const ChatBindDeviceToken = '
+        '@"updateAPNsPushToken";\n',
+        mode: FileMode.append,
+      );
+      File('${fixture.path}/ios/ClientWrapper.m').writeAsStringSync(
+        'if ([ChatBindDeviceToken isEqualToString:call.method]) {}\n',
+        mode: FileMode.append,
+      );
+
+      expect(checkContracts(fixture.path), isEmpty);
+    });
+  });
+}
+
+void _writeFixture(Directory fixture) {
+  Directory('${fixture.path}/dart').createSync(recursive: true);
+  Directory('${fixture.path}/android').createSync(recursive: true);
+  Directory('${fixture.path}/ios').createSync(recursive: true);
+
+  File('${fixture.path}/dart/chat_method_keys.dart').writeAsStringSync('''
+abstract final class ChatMethodKeys {
+  static const String login = 'login';
+  static const String logout = 'logout';
+}
+''');
+  File('${fixture.path}/dart/client.dart').writeAsStringSync('''
+Future<void> login() => channel.callNativeMethod(ChatMethodKeys.login);
+Future<void> logout() => channel.callNativeMethod(ChatMethodKeys.logout);
+''');
+  File('${fixture.path}/android/MethodKey.java').writeAsStringSync('''
+public final class MethodKey {
+  public static final String login = "login";
+  public static final String logout = "logout";
+}
+''');
+  File('${fixture.path}/android/ClientWrapper.java').writeAsStringSync('''
+switch (call.method) {
+  case MethodKey.login:
+    login(call);
+    break;
+  case MethodKey.logout:
+    logout(call);
+    break;
+}
+''');
+  File('${fixture.path}/ios/MethodKeys.h').writeAsStringSync('''
+static NSString *const EMMethodKeyLogin = @"login";
+static NSString *const EMMethodKeyLogout = @"logout";
+''');
+  File('${fixture.path}/ios/ClientWrapper.m').writeAsStringSync('''
+if ([call.method isEqualToString:EMMethodKeyLogin]) {
+  [self login:call];
+} else if ([call.method isEqualToString:EMMethodKeyLogout]) {
+  [self logout:call];
+}
+''');
+}

--- a/im_flutter_sdk/test/ci/version_checker_test.dart
+++ b/im_flutter_sdk/test/ci/version_checker_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/ci/version_checker.dart';
+
+void main() {
+  late Directory fixture;
+
+  setUp(() {
+    fixture = Directory.systemTemp.createTempSync('flutter-version-checker-');
+  });
+
+  tearDown(() {
+    fixture.deleteSync(recursive: true);
+  });
+
+  void write(String relativePath, String content) {
+    final file = File('${fixture.path}/$relativePath');
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(content);
+  }
+
+  void writeValidFixture() {
+    for (final package in <String>[
+      'im_flutter_sdk',
+      'im_flutter_sdk_android',
+      'im_flutter_sdk_ios',
+      'im_flutter_sdk_interface',
+    ]) {
+      write('$package/pubspec.yaml', 'name: $package\nversion: 4.19.2\n');
+    }
+    write(
+      'im_flutter_sdk_ios/ios/im_flutter_sdk_ios.podspec',
+      "s.version = '4.19.2'\ns.dependency 'HyphenateChat','4.19.1'\n",
+    );
+    write(
+      'im_flutter_sdk_android/android/build.gradle',
+      "implementation 'io.hyphenate:hyphenate-chat:4.19.3.1'\n",
+    );
+  }
+
+  test('accepts aligned federated and podspec versions', () {
+    writeValidFixture();
+
+    final result = checkVersions(fixture.path);
+
+    expect(result.errors, isEmpty);
+    expect(result.flutterVersion, '4.19.2');
+    expect(result.androidNativeVersion, '4.19.3.1');
+    expect(result.iosNativeVersion, '4.19.1');
+  });
+
+  test('reports every package and podspec mismatch', () {
+    writeValidFixture();
+    write(
+      'im_flutter_sdk_android/pubspec.yaml',
+      'name: im_flutter_sdk_android\nversion: 4.19.3\n',
+    );
+    write(
+      'im_flutter_sdk_ios/ios/im_flutter_sdk_ios.podspec',
+      "s.version = '4.15.2'\ns.dependency 'HyphenateChat','4.19.1'\n",
+    );
+
+    final result = checkVersions(fixture.path);
+
+    expect(result.errors, hasLength(2));
+    expect(result.errors.join('\n'), contains('im_flutter_sdk_android'));
+    expect(result.errors.join('\n'), contains('podspec'));
+  });
+}

--- a/im_flutter_sdk/test/handlers/presence_event_handler_test.dart
+++ b/im_flutter_sdk/test/handlers/presence_event_handler_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:im_flutter_sdk/im_flutter_sdk.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('presence handlers can be registered, replaced, removed, and cleared',
+      () {
+    final manager = EMClient.getInstance.presenceManager;
+    final first = EMPresenceEventHandler();
+    final replacement = EMPresenceEventHandler();
+
+    manager.addEventHandler('case', first);
+    expect(manager.getEventHandler('case'), same(first));
+
+    manager.addEventHandler('case', replacement);
+    expect(manager.getEventHandler('case'), same(replacement));
+
+    manager.removeEventHandler('case');
+    expect(manager.getEventHandler('case'), isNull);
+
+    manager.addEventHandler('one', first);
+    manager.addEventHandler('two', replacement);
+    manager.clearEventHandlers();
+    expect(manager.getEventHandler('one'), isNull);
+    expect(manager.getEventHandler('two'), isNull);
+  });
+}

--- a/im_flutter_sdk/test/managers/client_manager_test.dart
+++ b/im_flutter_sdk/test/managers/client_manager_test.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:im_flutter_sdk/im_flutter_sdk.dart';
+import 'package:im_flutter_sdk_interface/im_flutter_sdk_interface.dart';
+
+import '../support/recording_client.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Client originalClient;
+  late RecordingClient recordingClient;
+
+  setUp(() {
+    originalClient = Client.instance;
+    recordingClient = RecordingClient((manager, method, arguments) async {
+      return switch (method) {
+        'getCurrentUser' => <String, Object>{'getCurrentUser': 'unit-user'},
+        'isConnected' => <String, Object>{'isConnected': true},
+        'isLoggedInBefore' => <String, Object>{'isLoggedInBefore': true},
+        'getToken' => <String, Object>{'getToken': 'token-value'},
+        _ => <String, Object>{},
+      };
+    });
+    Client.instance = recordingClient;
+  });
+
+  tearDown(() {
+    Client.instance = originalClient;
+  });
+
+  Future<List<String>> captureLogs(Future<void> Function() action) async {
+    final logs = <String>[];
+    await runZoned(
+      action,
+      zoneSpecification: ZoneSpecification(
+        print: (self, parent, zone, line) => logs.add(line),
+      ),
+    );
+    return logs;
+  }
+
+  test('loginWithPassword sends a password login request', () async {
+    await EMClient.getInstance.loginWithPassword('unit-user', 'password');
+
+    final call = recordingClient.calls.single;
+    expect(call.method, 'login');
+    expect(call.arguments, <String, Object>{
+      'userId': 'unit-user',
+      'pwdOrToken': 'password',
+      'isPassword': true,
+    });
+    expect(EMClient.getInstance.currentUserId, 'unit-user');
+  });
+
+  test('client state APIs preserve native values', () async {
+    expect(await EMClient.getInstance.getCurrentUserId(), 'unit-user');
+    expect(await EMClient.getInstance.isConnected(), isTrue);
+    expect(await EMClient.getInstance.isLoginBefore(), isTrue);
+    expect(await EMClient.getInstance.getAccessToken(), 'token-value');
+  });
+
+  test('logout forwards unbind flag and clears current user', () async {
+    await EMClient.getInstance.loginWithPassword('unit-user', 'password');
+    recordingClient.calls.clear();
+
+    await EMClient.getInstance.logout(false);
+
+    expect(recordingClient.calls.single.method, 'logout');
+    expect(recordingClient.calls.single.arguments, <String, Object>{
+      'unbindToken': false,
+    });
+    expect(EMClient.getInstance.currentUserId, isNull);
+  });
+
+  test('client logs never expose credentials or app keys', () async {
+    const password = 'ci-super-secret-password';
+    const token = 'ci-super-secret-token';
+    const appKey = 'ci#super-secret-app-key';
+
+    final logs = await captureLogs(() async {
+      await EMClient.getInstance.init(EMOptions.withAppKey(appKey));
+      await EMClient.getInstance.createAccount('unit-user', password);
+      await EMClient.getInstance.loginWithPassword('unit-user', password);
+      await EMClient.getInstance.loginWithToken('unit-user', token);
+      await EMClient.getInstance.changeAppKey(newAppKey: appKey);
+    });
+
+    expect(logs, isNotEmpty);
+    expect(logs.join('\n'), isNot(contains(password)));
+    expect(logs.join('\n'), isNot(contains(token)));
+    expect(logs.join('\n'), isNot(contains(appKey)));
+  });
+}

--- a/im_flutter_sdk/test/managers/presence_manager_test.dart
+++ b/im_flutter_sdk/test/managers/presence_manager_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:im_flutter_sdk/im_flutter_sdk.dart';
+import 'package:im_flutter_sdk_interface/im_flutter_sdk_interface.dart';
+
+import '../support/recording_client.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Client originalClient;
+  late RecordingClient recordingClient;
+
+  setUp(() {
+    originalClient = Client.instance;
+    recordingClient = RecordingClient((manager, method, arguments) async {
+      return <String, Object>{
+        'error': <String, Object>{
+          'code': 201,
+          'description': 'platform-specific text',
+        },
+      };
+    });
+    Client.instance = recordingClient;
+  });
+
+  tearDown(() {
+    Client.instance = originalClient;
+  });
+
+  test('publishPresence forwards description and preserves error code',
+      () async {
+    await expectLater(
+      EMClient.getInstance.presenceManager.publishPresence('busy'),
+      throwsA(isA<EMError>().having((error) => error.code, 'code', 201)),
+    );
+    _expectOnlyCall(
+      recordingClient,
+      'publishPresenceWithDescription',
+      <String, Object>{'desc': 'busy'},
+    );
+  });
+
+  test('fetchPresenceStatus forwards members and preserves error code',
+      () async {
+    await expectLater(
+      EMClient.getInstance.presenceManager.fetchPresenceStatus(
+        members: <String>['user-a'],
+      ),
+      throwsA(isA<EMError>().having((error) => error.code, 'code', 201)),
+    );
+    _expectOnlyCall(recordingClient, 'fetchPresenceStatus', <String, Object>{
+      'members': <String>['user-a'],
+    });
+  });
+
+  test('subscribe forwards members and expiry and preserves error code',
+      () async {
+    await expectLater(
+      EMClient.getInstance.presenceManager.subscribe(
+        members: <String>['user-a'],
+        expiry: 60,
+      ),
+      throwsA(isA<EMError>().having((error) => error.code, 'code', 201)),
+    );
+    _expectOnlyCall(recordingClient, 'presenceSubscribe', <String, Object>{
+      'members': <String>['user-a'],
+      'expiry': 60,
+    });
+  });
+
+  test('unsubscribe forwards members and preserves error code', () async {
+    await expectLater(
+      EMClient.getInstance.presenceManager.unsubscribe(
+        members: <String>['user-a'],
+      ),
+      throwsA(isA<EMError>().having((error) => error.code, 'code', 201)),
+    );
+    _expectOnlyCall(recordingClient, 'presenceUnsubscribe', <String, Object>{
+      'members': <String>['user-a'],
+    });
+  });
+
+  test('fetchSubscribedMembers forwards page data and preserves error code',
+      () async {
+    await expectLater(
+      EMClient.getInstance.presenceManager.fetchSubscribedMembers(
+        pageNum: 2,
+        pageSize: 50,
+      ),
+      throwsA(isA<EMError>().having((error) => error.code, 'code', 201)),
+    );
+    _expectOnlyCall(
+        recordingClient, 'fetchSubscribedMembersWithPageNum', <String, Object>{
+      'pageNum': 2,
+      'pageSize': 50,
+    });
+  });
+}
+
+void _expectOnlyCall(
+  RecordingClient recordingClient,
+  String method,
+  Map<String, Object> arguments,
+) {
+  expect(recordingClient.calls, hasLength(1));
+  final call = recordingClient.calls.single;
+  expect(call.manager, 'presence');
+  expect(call.method, method);
+  expect(call.arguments, arguments);
+}

--- a/im_flutter_sdk/test/models/em_error_test.dart
+++ b/im_flutter_sdk/test/models/em_error_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:im_flutter_sdk/im_flutter_sdk.dart';
+
+void main() {
+  test('EMError preserves the native code and description', () {
+    final error = EMError.fromJson(<String, Object>{
+      'code': 201,
+      'description': 'User is not logged in',
+    });
+
+    expect(error.code, 201);
+    expect(error.description, 'User is not logged in');
+  });
+
+  test('hasErrorFromResult throws the native EMError', () {
+    expect(
+      () => EMError.hasErrorFromResult(<String, Object>{
+        'error': <String, Object>{
+          'code': 201,
+          'description': 'platform-specific text',
+        },
+      }),
+      throwsA(
+        isA<EMError>().having((error) => error.code, 'code', 201).having(
+              (error) => error.description,
+              'description',
+              'platform-specific text',
+            ),
+      ),
+    );
+  });
+
+  test('hasErrorFromResult accepts a successful result', () {
+    expect(
+      () => EMError.hasErrorFromResult(<String, Object>{'result': true}),
+      returnsNormally,
+    );
+  });
+}

--- a/im_flutter_sdk/test/models/em_message_test.dart
+++ b/im_flutter_sdk/test/models/em_message_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:im_flutter_sdk/im_flutter_sdk.dart';
+
+void main() {
+  group('EMMessage JSON contract', () {
+    test('text message round trip preserves routing and content', () {
+      final message = EMMessage.createTxtSendMessage(
+        targetId: 'receiver',
+        content: 'hello',
+      )
+        ..attributes = <String, Object>{'trace': 'unit'}
+        ..deliverOnlineOnly = true;
+
+      final decoded = EMMessage.fromJson(message.toJson());
+
+      expect(decoded.to, 'receiver');
+      expect(decoded.conversationId, 'receiver');
+      expect(decoded.direction, MessageDirection.SEND);
+      expect(decoded.body, isA<EMTextMessageBody>());
+      expect((decoded.body as EMTextMessageBody).content, 'hello');
+      expect(decoded.attributes, <String, Object>{'trace': 'unit'});
+      expect(decoded.deliverOnlineOnly, isTrue);
+    });
+
+    test('all locally constructible message types keep their body type', () {
+      final messages = <EMMessage>[
+        EMMessage.createTxtSendMessage(targetId: 'u', content: 'text'),
+        EMMessage.createLocationSendMessage(
+          targetId: 'u',
+          latitude: 1.5,
+          longitude: 2.5,
+          address: 'address',
+        ),
+        EMMessage.createCmdSendMessage(action: 'action', targetId: 'u'),
+        EMMessage.createCustomSendMessage(
+          targetId: 'u',
+          event: 'event',
+          params: <String, String>{'key': 'value'},
+        ),
+        EMMessage.createFileSendMessage(targetId: 'u', filePath: '/tmp/a'),
+        EMMessage.createImageSendMessage(targetId: 'u', filePath: '/tmp/a'),
+        EMMessage.createVoiceSendMessage(
+          targetId: 'u',
+          filePath: '/tmp/a',
+          duration: 2,
+        ),
+        EMMessage.createVideoSendMessage(
+          targetId: 'u',
+          filePath: '/tmp/a',
+          duration: 3,
+        ),
+        EMMessage.createCombineSendMessage(
+          targetId: 'u',
+          title: 'title',
+          summary: 'summary',
+          compatibleText: 'fallback',
+          msgIds: <String>['m1'],
+        ),
+      ];
+
+      for (final message in messages) {
+        final decoded = EMMessage.fromJson(message.toJson());
+        expect(decoded.body.runtimeType, message.body.runtimeType);
+        expect(decoded.chatType, ChatType.Chat);
+        expect(decoded.direction, MessageDirection.SEND);
+      }
+    });
+
+    test('received message round trip preserves unread state and sender', () {
+      final message = EMMessage.createReceiveMessage(
+        body: EMTextMessageBody(content: 'incoming'),
+      )
+        ..from = 'sender'
+        ..to = 'current-user'
+        ..conversationId = 'sender'
+        ..hasRead = false;
+
+      final decoded = EMMessage.fromJson(message.toJson());
+
+      expect(decoded.from, 'sender');
+      expect(decoded.to, 'current-user');
+      expect(decoded.conversationId, 'sender');
+      expect(decoded.direction, MessageDirection.RECEIVE);
+      expect(decoded.hasRead, isFalse);
+    });
+  });
+}

--- a/im_flutter_sdk/test/support/recording_client.dart
+++ b/im_flutter_sdk/test/support/recording_client.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/services.dart';
+import 'package:im_flutter_sdk_interface/im_flutter_sdk_interface.dart';
+
+typedef MethodResponder = Future<dynamic> Function(
+  String manager,
+  String method,
+  dynamic arguments,
+);
+
+final class RecordedCall {
+  const RecordedCall(this.manager, this.method, this.arguments);
+
+  final String manager;
+  final String method;
+  final dynamic arguments;
+}
+
+final class RecordingClient extends Client {
+  RecordingClient(this.responder);
+
+  final MethodResponder responder;
+  final List<RecordedCall> calls = <RecordedCall>[];
+
+  late final _RecordingManager _chat = _RecordingManager(this, 'chat');
+  late final _RecordingPresenceManager _presence =
+      _RecordingPresenceManager(this);
+  late final _RecordingManager _conversation =
+      _RecordingManager(this, 'conversation');
+
+  @override
+  ChatManager get chatManager => _chat;
+
+  @override
+  PresenceManager get presenceManager => _presence;
+
+  @override
+  ConversationManager get conversationManager => _conversation;
+
+  @override
+  Future<dynamic> callNativeMethod(String method, [dynamic params]) {
+    return record('client', method, params);
+  }
+
+  Future<dynamic> record(String manager, String method, dynamic params) {
+    calls.add(RecordedCall(manager, method, params));
+    return responder(manager, method, params);
+  }
+}
+
+final class _RecordingManager extends ChatManager
+    implements ConversationManager {
+  _RecordingManager(this.client, this.managerName);
+
+  final RecordingClient client;
+  final String managerName;
+
+  @override
+  Future<dynamic> callNativeMethod(String method, [dynamic params]) {
+    return client.record(managerName, method, params);
+  }
+
+  @override
+  void updateNativeHandler(
+      Future<dynamic> Function(MethodCall call)? handler) {}
+}
+
+final class _RecordingPresenceManager extends PresenceManager {
+  _RecordingPresenceManager(this.client);
+
+  final RecordingClient client;
+
+  @override
+  Future<dynamic> callNativeMethod(String method, [dynamic params]) {
+    return client.record('presence', method, params);
+  }
+
+  @override
+  void updateNativeHandler(
+      Future<dynamic> Function(MethodCall call)? handler) {}
+}

--- a/im_flutter_sdk/tool/ci/case_mapping_checker.dart
+++ b/im_flutter_sdk/tool/ci/case_mapping_checker.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'dart:io';
+
+List<String> checkCaseMapping(String packageRoot) {
+  final errors = <String>[];
+  final mappingFile = File('$packageRoot/docs/ci/native-case-mapping.json');
+  if (!mappingFile.existsSync()) {
+    return <String>['Missing mapping: ${mappingFile.path}'];
+  }
+
+  Object? decoded;
+  try {
+    decoded = jsonDecode(mappingFile.readAsStringSync());
+  } on FormatException catch (error) {
+    return <String>['Invalid mapping JSON: ${error.message}'];
+  }
+  if (decoded is! Map<String, dynamic>) {
+    return <String>['Mapping root must be an object'];
+  }
+  if (decoded['schemaVersion'] != 1) {
+    errors.add('schemaVersion must be 1');
+  }
+  if ((decoded['nativeBaseline'] as String?)?.isEmpty ?? true) {
+    errors.add('nativeBaseline must not be empty');
+  }
+
+  final cases = decoded['cases'];
+  if (cases is! List) {
+    errors.add('cases must be a list');
+    return errors;
+  }
+
+  final ids = <String>{};
+  for (final rawCase in cases) {
+    if (rawCase is! Map<String, dynamic>) {
+      errors.add('Every case must be an object');
+      continue;
+    }
+    final id = rawCase['id'] as String? ?? '<missing-id>';
+    if (!RegExp(r'^FL-[A-Z]+-\d{3}$').hasMatch(id)) {
+      errors.add('$id: invalid case id');
+    } else if (!ids.add(id)) {
+      errors.add('$id: duplicate case id');
+    }
+
+    if (!const <String>{'P0', 'P1', 'P2'}.contains(rawCase['priority'])) {
+      errors.add('$id: priority must be P0, P1, or P2');
+    }
+    final origin = rawCase['origin'];
+    if (!const <String>{'flutter-only', 'native-shared'}.contains(origin)) {
+      errors.add('$id: invalid origin');
+    }
+
+    final sourceCases = _stringList(rawCase['sourceCases']);
+    if (origin == 'native-shared' && sourceCases.isEmpty) {
+      errors.add('$id: native-shared requires sourceCases');
+    }
+    if (origin == 'flutter-only' && sourceCases.isNotEmpty) {
+      errors.add('$id: flutter-only sourceCases must be empty');
+    }
+
+    for (final field in <String>['flutterApis', 'platforms', 'assertions']) {
+      if (_stringList(rawCase[field]).isEmpty) {
+        errors.add('$id: $field must not be empty');
+      }
+    }
+
+    final platforms = _stringList(rawCase['platforms']).toSet();
+    if (platforms.difference(const <String>{'android', 'ios'}).isNotEmpty) {
+      errors.add('$id: platforms may only contain android and ios');
+    }
+
+    final testFile = rawCase['testFile'] as String? ?? '';
+    final implementation = File('$packageRoot/$testFile');
+    if (!implementation.existsSync()) {
+      errors.add('$id: missing test file $testFile');
+    } else if (!implementation.readAsStringSync().contains(id)) {
+      errors.add('$id: id not found in $testFile');
+    }
+  }
+
+  return errors;
+}
+
+List<String> _stringList(Object? value) {
+  if (value is! List) {
+    return const <String>[];
+  }
+  return value.whereType<String>().where((item) => item.isNotEmpty).toList();
+}

--- a/im_flutter_sdk/tool/ci/check_case_mapping.dart
+++ b/im_flutter_sdk/tool/ci/check_case_mapping.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'case_mapping_checker.dart';
+
+void main(List<String> arguments) {
+  final packageRoot = arguments.isEmpty ? '.' : arguments.single;
+  final errors = checkCaseMapping(packageRoot);
+  if (errors.isNotEmpty) {
+    for (final error in errors) {
+      stderr.writeln(error);
+    }
+    exitCode = 1;
+    return;
+  }
+  stdout.writeln('Native-to-Flutter case mapping is valid.');
+}

--- a/im_flutter_sdk/tool/ci/check_contracts.dart
+++ b/im_flutter_sdk/tool/ci/check_contracts.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+
+import 'contract_checker.dart';
+
+void main(List<String> arguments) {
+  final repositoryRoot = arguments.isEmpty
+      ? Directory.current.parent.path
+      : Directory(arguments.single).absolute.path;
+  final errors = checkContracts(repositoryRoot);
+  if (errors.isEmpty) {
+    stdout.writeln('MethodChannel contracts are consistent.');
+    return;
+  }
+
+  for (final error in errors) {
+    stderr.writeln(error);
+  }
+  exitCode = 1;
+}

--- a/im_flutter_sdk/tool/ci/check_versions.dart
+++ b/im_flutter_sdk/tool/ci/check_versions.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'version_checker.dart';
+
+void main(List<String> arguments) {
+  final repositoryRoot = arguments.isEmpty ? '..' : arguments.single;
+  final result = checkVersions(repositoryRoot);
+
+  if (result.errors.isNotEmpty) {
+    for (final error in result.errors) {
+      stderr.writeln(error);
+    }
+    exitCode = 1;
+    return;
+  }
+
+  stdout.writeln(
+    'Versions are consistent: Flutter ${result.flutterVersion}, '
+    'Android Native ${result.androidNativeVersion}, '
+    'iOS Native ${result.iosNativeVersion}.',
+  );
+}

--- a/im_flutter_sdk/tool/ci/contract_checker.dart
+++ b/im_flutter_sdk/tool/ci/contract_checker.dart
@@ -1,0 +1,176 @@
+import 'dart:io';
+
+final RegExp _dartConstant = RegExp(
+  r'''static\s+const\s+String\s+(\w+)\s*=\s*["']([^"']+)["']''',
+);
+final RegExp _androidConstant = RegExp(
+  r'''static\s+final\s+String\s+(\w+)\s*=\s*["']([^"']+)["']''',
+);
+final RegExp _iosConstant = RegExp(
+  r'''static\s+NSString\s*\*\s*const\s+(\w+)\s*=\s*@["']([^"']+)["']''',
+);
+final RegExp _dartInvocation = RegExp(
+  r'callNativeMethod\s*\(\s*ChatMethodKeys\.(\w+)',
+  multiLine: true,
+);
+
+List<String> checkContracts(String repositoryRoot) {
+  final layout = _ContractLayout.fromRoot(repositoryRoot);
+  final dartConstants = _readConstants(layout.dartConstants, _dartConstant);
+  final androidConstants =
+      _readConstants(layout.androidConstants, _androidConstant);
+  final iosConstants = _readConstants(layout.iosConstants, _iosConstant);
+  final androidNamesByValue = <String, String>{
+    for (final entry in androidConstants.entries) entry.value: entry.key,
+  };
+  final iosNamesByValue = <String, String>{
+    for (final entry in iosConstants.entries) entry.value: entry.key,
+  };
+  final invokedNames = _readDartInvocations(layout.dartSourceDirectory);
+  final androidRoutes = _readFiles(layout.androidRoutes, '.java');
+  final iosRoutes = _readFiles(layout.iosRoutes, '.m');
+  final errors = <String>[];
+
+  for (final name in invokedNames.toList()..sort()) {
+    final dartValue = dartConstants[name];
+    final androidName = dartValue == null
+        ? null
+        : _matchingPlatformName(
+            dartName: name,
+            dartValue: dartValue,
+            platformConstants: androidConstants,
+            namesByValue: androidNamesByValue,
+          );
+    final androidValue =
+        androidName == null ? null : androidConstants[androidName];
+    final iosName = dartValue == null ? null : iosNamesByValue[dartValue];
+    final iosValue = iosName == null ? null : iosConstants[iosName];
+    final requiresAndroid = name != 'updateAPNsPushToken';
+    final requiresIos = name != 'updateHMSPushToken';
+
+    if (dartValue == null ||
+        (requiresAndroid &&
+            (androidValue == null || dartValue != androidValue)) ||
+        (requiresIos && (iosValue == null || dartValue != iosValue))) {
+      errors.add(
+        'Method key mismatch: $name '
+        'dart=${dartValue ?? '<missing>'} '
+        'android=${androidValue ?? '<missing>'} '
+        'ios=${iosValue ?? '<missing>'}',
+      );
+      continue;
+    }
+
+    if (requiresAndroid &&
+        !androidRoutes.contains('MethodKey.${androidName!}')) {
+      errors.add('Android route missing: $name');
+    }
+    if (requiresIos && !iosRoutes.contains(iosName!)) {
+      errors.add('iOS route missing: $name');
+    }
+  }
+
+  return errors;
+}
+
+String? _matchingPlatformName({
+  required String dartName,
+  required String dartValue,
+  required Map<String, String> platformConstants,
+  required Map<String, String> namesByValue,
+}) {
+  final sameNameValue = platformConstants[dartName];
+  if (sameNameValue != null) {
+    return dartName;
+  }
+  return namesByValue[dartValue];
+}
+
+Map<String, String> _readConstants(File file, RegExp pattern) {
+  if (!file.existsSync()) {
+    return const {};
+  }
+  return <String, String>{
+    for (final match in pattern.allMatches(file.readAsStringSync()))
+      match.group(1)!: match.group(2)!,
+  };
+}
+
+Set<String> _readDartInvocations(Directory directory) {
+  if (!directory.existsSync()) {
+    return const {};
+  }
+  final names = <String>{};
+  for (final entity in directory.listSync(recursive: true)) {
+    if (entity is! File || !entity.path.endsWith('.dart')) {
+      continue;
+    }
+    for (final match in _dartInvocation.allMatches(entity.readAsStringSync())) {
+      names.add(match.group(1)!);
+    }
+  }
+  return names;
+}
+
+String _readFiles(Directory directory, String extension) {
+  if (!directory.existsSync()) {
+    return '';
+  }
+  return directory
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((file) => file.path.endsWith(extension))
+      .map((file) => file.readAsStringSync())
+      .join('\n');
+}
+
+final class _ContractLayout {
+  const _ContractLayout({
+    required this.dartConstants,
+    required this.dartSourceDirectory,
+    required this.androidConstants,
+    required this.androidRoutes,
+    required this.iosConstants,
+    required this.iosRoutes,
+  });
+
+  factory _ContractLayout.fromRoot(String root) {
+    final fixtureDart = Directory('$root/dart');
+    if (fixtureDart.existsSync()) {
+      return _ContractLayout(
+        dartConstants: File('$root/dart/chat_method_keys.dart'),
+        dartSourceDirectory: fixtureDart,
+        androidConstants: File('$root/android/MethodKey.java'),
+        androidRoutes: Directory('$root/android'),
+        iosConstants: File('$root/ios/MethodKeys.h'),
+        iosRoutes: Directory('$root/ios'),
+      );
+    }
+
+    return _ContractLayout(
+      dartConstants: File(
+        '$root/im_flutter_sdk/lib/src/internal/chat_method_keys.dart',
+      ),
+      dartSourceDirectory: Directory('$root/im_flutter_sdk/lib/src'),
+      androidConstants: File(
+        '$root/im_flutter_sdk_android/android/src/main/java/'
+        'com/easemob/im_flutter_sdk/MethodKey.java',
+      ),
+      androidRoutes: Directory(
+        '$root/im_flutter_sdk_android/android/src/main/java/'
+        'com/easemob/im_flutter_sdk',
+      ),
+      iosConstants: File(
+        '$root/im_flutter_sdk_ios/ios/Classes/MethodKeys.h',
+      ),
+      iosRoutes: Directory('$root/im_flutter_sdk_ios/ios/Classes'),
+    );
+  }
+
+  final File dartConstants;
+  final Directory dartSourceDirectory;
+  final File androidConstants;
+  final Directory androidRoutes;
+  final File iosConstants;
+  final Directory iosRoutes;
+}

--- a/im_flutter_sdk/tool/ci/version_checker.dart
+++ b/im_flutter_sdk/tool/ci/version_checker.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+const _packagePaths = <String>[
+  'im_flutter_sdk',
+  'im_flutter_sdk_android',
+  'im_flutter_sdk_ios',
+  'im_flutter_sdk_interface',
+];
+
+class VersionCheckResult {
+  const VersionCheckResult({
+    required this.errors,
+    required this.flutterVersion,
+    required this.androidNativeVersion,
+    required this.iosNativeVersion,
+  });
+
+  final List<String> errors;
+  final String flutterVersion;
+  final String androidNativeVersion;
+  final String iosNativeVersion;
+}
+
+VersionCheckResult checkVersions(String repositoryRoot) {
+  final errors = <String>[];
+  final packageVersions = <String, String>{};
+
+  for (final packagePath in _packagePaths) {
+    final path = '$repositoryRoot/$packagePath/pubspec.yaml';
+    packageVersions[packagePath] = _readMatch(
+      path,
+      RegExp(r'^version:\s*([^\s]+)\s*$', multiLine: true),
+      'version',
+      errors,
+    );
+  }
+
+  final flutterVersion = packageVersions['im_flutter_sdk'] ?? '';
+  for (final entry in packageVersions.entries) {
+    if (entry.value.isNotEmpty && entry.value != flutterVersion) {
+      errors.add(
+        '${entry.key}/pubspec.yaml version ${entry.value} '
+        'does not match im_flutter_sdk $flutterVersion',
+      );
+    }
+  }
+
+  final podspecVersion = _readMatch(
+    '$repositoryRoot/im_flutter_sdk_ios/ios/im_flutter_sdk_ios.podspec',
+    RegExp(r'''s\.version\s*=\s*['"]([^'"]+)['"]'''),
+    'podspec version',
+    errors,
+  );
+  if (podspecVersion.isNotEmpty && podspecVersion != flutterVersion) {
+    errors.add(
+      'iOS podspec version $podspecVersion does not match '
+      'im_flutter_sdk $flutterVersion',
+    );
+  }
+
+  final androidNativeVersion = _readMatch(
+    '$repositoryRoot/im_flutter_sdk_android/android/build.gradle',
+    RegExp(r'''io\.hyphenate:hyphenate-chat:([^'"]+)'''),
+    'Android Native SDK version',
+    errors,
+  );
+  final iosNativeVersion = _readMatch(
+    '$repositoryRoot/im_flutter_sdk_ios/ios/im_flutter_sdk_ios.podspec',
+    RegExp(r'''s\.dependency\s+['"]HyphenateChat['"]\s*,\s*['"]([^'"]+)'''),
+    'iOS Native SDK version',
+    errors,
+  );
+
+  return VersionCheckResult(
+    errors: errors,
+    flutterVersion: flutterVersion,
+    androidNativeVersion: androidNativeVersion,
+    iosNativeVersion: iosNativeVersion,
+  );
+}
+
+String _readMatch(
+  String path,
+  RegExp pattern,
+  String field,
+  List<String> errors,
+) {
+  final file = File(path);
+  if (!file.existsSync()) {
+    errors.add('Missing file for $field: $path');
+    return '';
+  }
+
+  final match = pattern.firstMatch(file.readAsStringSync());
+  if (match == null) {
+    errors.add('Could not find $field in $path');
+    return '';
+  }
+  return match.group(1)!;
+}

--- a/im_flutter_sdk_android/analysis_options.yaml
+++ b/im_flutter_sdk_android/analysis_options.yaml
@@ -1,3 +1,15 @@
+analyzer:
+  errors:
+    # Federated packages intentionally use local path dependencies in source.
+    invalid_dependency: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/im_flutter_sdk_interface/analysis_options.yaml
+++ b/im_flutter_sdk_interface/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/im_flutter_sdk_ios/analysis_options.yaml
+++ b/im_flutter_sdk_ios/analysis_options.yaml
@@ -1,3 +1,15 @@
+analyzer:
+  errors:
+    # Federated packages intentionally use local path dependencies in source.
+    invalid_dependency: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/im_flutter_sdk_ios/ios/im_flutter_sdk_ios.podspec
+++ b/im_flutter_sdk_ios/ios/im_flutter_sdk_ios.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'im_flutter_sdk_ios'
-  s.version          = '4.15.2'
+  s.version          = '4.19.2'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.
@@ -24,4 +24,3 @@ A new flutter plugin project.
   s.ios.deployment_target = '12.0'
 
 end
-

--- a/tool/ci/boot_ios_simulator.sh
+++ b/tool/ci/boot_ios_simulator.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+udid="$({
+  xcrun simctl list devices available --json | ruby -rjson -e '
+    devices = JSON.parse(STDIN.read).fetch("devices").values.flatten
+    iphone = devices.find { |device| device.fetch("name", "").start_with?("iPhone") }
+    abort "No available iPhone simulator was found" unless iphone
+    puts iphone.fetch("udid")
+  '
+})"
+
+xcrun simctl boot "$udid" 2>/dev/null || true
+xcrun simctl bootstatus "$udid" -b >&2
+printf '%s\n' "$udid"

--- a/tool/ci/run_quality.sh
+++ b/tool/ci/run_quality.sh
@@ -17,11 +17,27 @@ for package in "${packages[@]}"; do
   )
 done
 
-dart format --output=none --set-exit-if-changed \
-  "$repo_root/im_flutter_sdk/lib" \
-  "$repo_root/im_flutter_sdk/test" \
-  "$repo_root/im_flutter_sdk/tool" \
-  "$repo_root/im_flutter_sdk/example/integration_test"
+format_base="${FORMAT_BASE_SHA:-}"
+if [[ -z "$format_base" || "$format_base" =~ ^0+$ ]] || \
+  ! git -C "$repo_root" cat-file -e "${format_base}^{commit}" 2>/dev/null; then
+  format_base="$(git -C "$repo_root" rev-parse HEAD^ 2>/dev/null || true)"
+fi
+
+format_files=()
+if [[ -n "$format_base" ]]; then
+  while IFS= read -r file; do
+    [[ -n "$file" ]] && format_files+=("$repo_root/$file")
+  done < <(
+    git -C "$repo_root" diff --name-only --diff-filter=ACMR \
+      "$format_base" -- '*.dart'
+  )
+fi
+
+if (( ${#format_files[@]} > 0 )); then
+  dart format --output=none --set-exit-if-changed "${format_files[@]}"
+else
+  echo "No changed Dart files require format checking."
+fi
 
 for package in "${packages[@]}"; do
   (

--- a/tool/ci/run_quality.sh
+++ b/tool/ci/run_quality.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+packages=(
+  im_flutter_sdk_interface
+  im_flutter_sdk_android
+  im_flutter_sdk_ios
+  im_flutter_sdk
+  im_flutter_sdk/example
+)
+
+for package in "${packages[@]}"; do
+  (
+    cd "$repo_root/$package"
+    flutter pub get
+  )
+done
+
+dart format --output=none --set-exit-if-changed \
+  "$repo_root/im_flutter_sdk/lib" \
+  "$repo_root/im_flutter_sdk/test" \
+  "$repo_root/im_flutter_sdk/tool" \
+  "$repo_root/im_flutter_sdk/example/integration_test"
+
+for package in "${packages[@]}"; do
+  (
+    cd "$repo_root/$package"
+    flutter analyze --fatal-infos
+  )
+done
+
+(
+  cd "$repo_root/im_flutter_sdk"
+  flutter test --coverage
+  dart run tool/ci/check_case_mapping.dart .
+  dart run tool/ci/check_contracts.dart ..
+  dart run tool/ci/check_versions.dart ..
+)

--- a/tool/ci/write_e2e_dart_defines.sh
+++ b/tool/ci/write_e2e_dart_defines.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_path="${1:?usage: write_e2e_dart_defines.sh OUTPUT_PATH}"
+required=(E2E_APP_KEY E2E_USER_ID E2E_USER_PASSWORD)
+
+for name in "${required[@]}"; do
+  if [[ -z "${!name:-}" ]]; then
+    printf 'Required environment variable %s is empty\n' "$name" >&2
+    exit 1
+  fi
+done
+
+umask 077
+jq -n \
+  --arg app_key "$E2E_APP_KEY" \
+  --arg user_id "$E2E_USER_ID" \
+  --arg password "$E2E_USER_PASSWORD" \
+  '{
+    E2E_APP_KEY: $app_key,
+    E2E_USER_ID: $user_id,
+    E2E_USER_PASSWORD: $password
+  }' >"$output_path"
+
+printf 'E2E dart-define file created with mode 0600\n'


### PR DESCRIPTION
## What changed

- add standalone Flutter PR quality, Android build, and iOS simulator build jobs
- add scheduled Android/iOS no-login device smoke coverage
- add protected single-account coverage as a manual workflow without depending on Test Hub
- add version, MethodChannel contract, Native-case mapping, and credential-redaction checks
- pin hosted runners to Ubuntu 24.04 and macOS 26, with Xcode 26.3 selected explicitly

## Why

Flutter previously had no repository-owned CI comparable to the Android and iOS SDK foundations. This PR establishes a first phase that is self-contained in `im_flutter_sdk`, requires no cross-repository checkout, and can become the default branch quality gate before Test Hub integration is introduced.

## Impact

Pull requests run secret-free quality and dual-platform build checks. No-login device smoke remains scheduled or manual. Single-account coverage is manual-only until the protected `flutter-single-account` Environment and its credentials are configured, so fork pull requests never receive E2E credentials.

## Validation

- `tool/ci/run_quality.sh`: 27 tests passed; format, analyze, version, contract, and case mapping checks passed
- Android emulator: 6/6 no-login smoke cases passed
- iOS 26.0 simulator with Xcode 26.3: build completed and 6/6 no-login smoke cases passed
- `actionlint v1.7.12 .github/workflows/*.yml`: passed

This draft PR is also the first hosted-runner trial for the new `Flutter CI` workflow.
