### PR TITLE
fix(ci): repair device workflows on Android emulator and iOS simulator

### DIFF
--- a/.github/workflows/device-smoke.yml
+++ b/.github/workflows/device-smoke.yml
@@ -38,6 +38,16 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Enable KVM group perms
+        # The ubuntu-24.04 runner image has /dev/kvm but the runner user is
+        # not in the kvm group (actions/runner-images#8542). Without this
+        # udev rule the emulator silently falls back to ~10x slower software
+        # emulation and the job times out before the app starts.
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run no-login smoke on Android emulator
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
@@ -45,12 +55,9 @@ jobs:
           arch: x86_64
           profile: pixel_6
           disable-animations: true
-          script: |
-            mkdir -p artifacts
-            cd im_flutter_sdk/example
-            flutter pub get
-            set -o pipefail
-            flutter test integration_test/no_login_presence_test.dart -d emulator-5554 2>&1 | tee ../../artifacts/android-no-login-smoke.log
+          # Multi-line scripts are not run in one shell session by the
+          # runner, so the real steps live in a wrapper script.
+          script: bash tool/ci/run_android_emulator_test.sh integration_test/no_login_presence_test.dart android-no-login-smoke.log
 
       - name: Upload Android smoke log
         if: always()
@@ -64,7 +71,7 @@ jobs:
   ios:
     name: iOS no-login Presence smoke
     runs-on: macos-26
-    timeout-minutes: 45
+    timeout-minutes: 25
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
@@ -79,18 +86,12 @@ jobs:
           cache: true
 
       - name: Run no-login smoke on iOS simulator
-        run: |
-          mkdir -p artifacts
-          simulator_udid="$(./tool/ci/boot_ios_simulator.sh)"
-          echo "Using iOS simulator $simulator_udid"
-          cd im_flutter_sdk/example
-          flutter pub get
-          set -o pipefail
-          flutter test integration_test/no_login_presence_test.dart -d "$simulator_udid" 2>&1 | tee ../../artifacts/ios-no-login-smoke.log
+        run: ./tool/ci/run_ios_simulator_test.sh integration_test/no_login_presence_test.dart ios-no-login-smoke.log
 
       - name: Collect iOS diagnostics after failure
         if: failure()
-        run: xcrun simctl diagnose --output artifacts/ios-sim-diagnose.tar.gz
+        # --output expects a directory; the archive name is generated.
+        run: xcrun simctl diagnose -b --output artifacts || true
 
       - name: Upload iOS smoke evidence
         if: always()
@@ -99,6 +100,6 @@ jobs:
           name: flutter-device-smoke-ios-${{ github.run_id }}
           path: |
             artifacts/ios-no-login-smoke.log
-            artifacts/ios-sim-diagnose.tar.gz
+            artifacts/*diagnose*.tar.gz
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/single-account-nightly.yml
+++ b/.github/workflows/single-account-nightly.yml
@@ -46,6 +46,16 @@ jobs:
           ./tool/ci/write_e2e_dart_defines.sh "$RUNNER_TEMP/flutter-single-account.json"
           echo "E2E_CONFIG_PATH=$RUNNER_TEMP/flutter-single-account.json" >> "$GITHUB_ENV"
 
+      - name: Enable KVM group perms
+        # The ubuntu-24.04 runner image has /dev/kvm but the runner user is
+        # not in the kvm group (actions/runner-images#8542). Without this
+        # udev rule the emulator silently falls back to ~10x slower software
+        # emulation and the job times out before the app starts.
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run login and local database suite on Android emulator
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
@@ -53,12 +63,9 @@ jobs:
           arch: x86_64
           profile: pixel_6
           disable-animations: true
-          script: |
-            mkdir -p artifacts
-            cd im_flutter_sdk/example
-            flutter pub get
-            set -o pipefail
-            flutter test integration_test/single_account_local_test.dart -d emulator-5554 --dart-define-from-file="$E2E_CONFIG_PATH" 2>&1 | tee ../../artifacts/android-single-account.log
+          # Multi-line scripts are not run in one shell session by the
+          # runner, so the real steps live in a wrapper script.
+          script: bash tool/ci/run_android_emulator_test.sh integration_test/single_account_local_test.dart android-single-account.log
 
       - name: Remove protected test configuration
         if: always()
@@ -78,7 +85,7 @@ jobs:
     needs: android
     if: ${{ always() }}
     runs-on: macos-26
-    timeout-minutes: 50
+    timeout-minutes: 25
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     environment: flutter-single-account
@@ -103,18 +110,12 @@ jobs:
           echo "E2E_CONFIG_PATH=$RUNNER_TEMP/flutter-single-account.json" >> "$GITHUB_ENV"
 
       - name: Run login and local database suite on iOS simulator
-        run: |
-          mkdir -p artifacts
-          simulator_udid="$(./tool/ci/boot_ios_simulator.sh)"
-          echo "Using iOS simulator $simulator_udid"
-          cd im_flutter_sdk/example
-          flutter pub get
-          set -o pipefail
-          flutter test integration_test/single_account_local_test.dart -d "$simulator_udid" --dart-define-from-file="$E2E_CONFIG_PATH" 2>&1 | tee ../../artifacts/ios-single-account.log
+        run: ./tool/ci/run_ios_simulator_test.sh integration_test/single_account_local_test.dart ios-single-account.log
 
       - name: Collect iOS diagnostics after failure
         if: failure()
-        run: xcrun simctl diagnose --output artifacts/ios-sim-diagnose.tar.gz
+        # --output expects a directory; the archive name is generated.
+        run: xcrun simctl diagnose -b --output artifacts || true
 
       - name: Remove protected test configuration
         if: always()
@@ -127,6 +128,6 @@ jobs:
           name: flutter-single-account-ios-${{ github.run_id }}
           path: |
             artifacts/ios-single-account.log
-            artifacts/ios-sim-diagnose.tar.gz
+            artifacts/*diagnose*.tar.gz
           if-no-files-found: warn
           retention-days: 7

--- a/tool/ci/run_android_emulator_test.sh
+++ b/tool/ci/run_android_emulator_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Runs a flutter integration test on the Android emulator started by
+# reactivecircus/android-emulator-runner. The runner does not preserve
+# multi-line `script:` input as one shell session (each line can end up in
+# its own `sh -c`, so `cd` does not stick), so the workflows invoke this
+# wrapper with a single-line script instead.
+set -euo pipefail
+
+test_target="${1:?usage: run_android_emulator_test.sh TEST_TARGET LOG_NAME}"
+log_name="${2:?usage: run_android_emulator_test.sh TEST_TARGET LOG_NAME}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+mkdir -p "$repo_root/artifacts"
+
+cd "$repo_root/im_flutter_sdk/example"
+flutter pub get
+
+extra_args=()
+if [[ -n "${E2E_CONFIG_PATH:-}" ]]; then
+  extra_args+=(--dart-define-from-file="$E2E_CONFIG_PATH")
+fi
+
+set -o pipefail
+flutter test "$test_target" -d emulator-5554 "${extra_args[@]}" 2>&1 | tee "$repo_root/artifacts/$log_name"

--- a/tool/ci/run_ios_simulator_test.sh
+++ b/tool/ci/run_ios_simulator_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Runs a flutter integration test on a booted iOS simulator with a watchdog.
+# `flutter test` can hang forever while discovering the Dart VM Service (seen
+# on iOS 26 simulators), so the test process is killed after WATCHDOG_SECONDS
+# and the step fails normally, letting the diagnose step collect evidence
+# instead of the whole job timing out with nothing.
+set -euo pipefail
+
+test_target="${1:?usage: run_ios_simulator_test.sh TEST_TARGET LOG_NAME}"
+log_name="${2:?usage: run_ios_simulator_test.sh TEST_TARGET LOG_NAME}"
+watchdog_seconds="${WATCHDOG_SECONDS:-720}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+mkdir -p "$repo_root/artifacts"
+log_file="$repo_root/artifacts/$log_name"
+
+simulator_udid="$("$repo_root/tool/ci/boot_ios_simulator.sh")"
+echo "Using iOS simulator $simulator_udid"
+
+cd "$repo_root/im_flutter_sdk/example"
+flutter pub get
+
+extra_args=()
+if [[ -n "${E2E_CONFIG_PATH:-}" ]]; then
+  extra_args+=(--dart-define-from-file="$E2E_CONFIG_PATH")
+fi
+
+flutter test "$test_target" -d "$simulator_udid" "${extra_args[@]}" >"$log_file" 2>&1 &
+test_pid=$!
+(
+  sleep "$watchdog_seconds"
+  echo "Watchdog: flutter test exceeded ${watchdog_seconds}s, killing it" >&2
+  kill -TERM "$test_pid" 2>/dev/null || true
+  sleep 15
+  kill -KILL "$test_pid" 2>/dev/null || true
+) &
+watchdog_pid=$!
+
+status=0
+wait "$test_pid" || status=$?
+kill "$watchdog_pid" 2>/dev/null || true
+
+cat "$log_file"
+if [[ "$status" -ne 0 ]]; then
+  echo "iOS simulator test failed or was killed by the ${watchdog_seconds}s watchdog" >&2
+fi
+exit "$status"


### PR DESCRIPTION
- Run Android emulator tests via tool/ci/run_android_emulator_test.sh because android-emulator-runner does not keep a multi-line script in one shell session (each line can land in its own sh -c, so cd/pub get ran in the wrong directory)
- Add a udev rule for /dev/kvm before the Android emulator steps: the ubuntu-24.04 runner user is not in the kvm group (actions/runner-images#8542), so the emulator silently fell back to much slower software emulation
- Run iOS simulator tests via tool/ci/run_ios_simulator_test.sh with a 12-minute watchdog so a hung Dart VM Service discovery fails the step and triggers diagnostics instead of burning the whole job timeout
- Fix simctl diagnose invocation: --output expects a directory, and the generated archive name now matches the upload-artifact glob
- Lower iOS job timeouts from 45/50 to 25 minutes