### PR TITLE
fix(ci): make device test scripts work on bash 3.2

### DIFF
--- a/tool/ci/run_android_emulator_test.sh
+++ b/tool/ci/run_android_emulator_test.sh
@@ -15,10 +15,12 @@ mkdir -p "$repo_root/artifacts"
 cd "$repo_root/im_flutter_sdk/example"
 flutter pub get
 
-extra_args=()
+# Keep the array non-empty: expanding an empty array under set -u fails
+# on bash 3.2 (e.g. when this script is run locally on macOS).
+command=(flutter test "$test_target" -d emulator-5554)
 if [[ -n "${E2E_CONFIG_PATH:-}" ]]; then
-  extra_args+=(--dart-define-from-file="$E2E_CONFIG_PATH")
+  command+=(--dart-define-from-file="$E2E_CONFIG_PATH")
 fi
 
 set -o pipefail
-flutter test "$test_target" -d emulator-5554 "${extra_args[@]}" 2>&1 | tee "$repo_root/artifacts/$log_name"
+"${command[@]}" 2>&1 | tee "$repo_root/artifacts/$log_name"

--- a/tool/ci/run_ios_simulator_test.sh
+++ b/tool/ci/run_ios_simulator_test.sh
@@ -20,12 +20,14 @@ echo "Using iOS simulator $simulator_udid"
 cd "$repo_root/im_flutter_sdk/example"
 flutter pub get
 
-extra_args=()
+# Note: keep the array non-empty; expanding an empty array under set -u
+# fails on macOS's bash 3.2, which is what the GitHub macOS runners use.
+command=(flutter test "$test_target" -d "$simulator_udid")
 if [[ -n "${E2E_CONFIG_PATH:-}" ]]; then
-  extra_args+=(--dart-define-from-file="$E2E_CONFIG_PATH")
+  command+=(--dart-define-from-file="$E2E_CONFIG_PATH")
 fi
 
-flutter test "$test_target" -d "$simulator_udid" "${extra_args[@]}" >"$log_file" 2>&1 &
+"${command[@]}" >"$log_file" 2>&1 &
 test_pid=$!
 (
   sleep "$watchdog_seconds"
@@ -38,7 +40,9 @@ watchdog_pid=$!
 
 status=0
 wait "$test_pid" || status=$?
+# Reap the watchdog so bash does not print a "Terminated" job notice.
 kill "$watchdog_pid" 2>/dev/null || true
+wait "$watchdog_pid" 2>/dev/null || true
 
 cat "$log_file"
 if [[ "$status" -ne 0 ]]; then


### PR DESCRIPTION
Expanding an empty array under set -u fails on the bash 3.2 shipped with macOS (which is also what the GitHub macOS runners use), so build the flutter test command as a non-empty array in both wrapper scripts. Also reap the iOS watchdog after killing it so bash does not print a Terminated job notice at the end of a passing run.