### PR TITLE
fix(ci): retry zero-test iOS runs and repair simctl diagnose

### DIFF
--- a/.github/workflows/device-smoke.yml
+++ b/.github/workflows/device-smoke.yml
@@ -90,8 +90,10 @@ jobs:
 
       - name: Collect iOS diagnostics after failure
         if: failure()
-        # --output expects a directory; the archive name is generated.
-        run: xcrun simctl diagnose -b --output artifacts || true
+        # Xcode 26 simctl only accepts --output=<path> (equals form) and
+        # pauses on an interactive "Press ENTER" prompt unless stdin is fed.
+        # The archive is written as <path>.tar.gz next to the given path.
+        run: echo | xcrun simctl diagnose -b --output=artifacts/diagnose || true
 
       - name: Upload iOS smoke evidence
         if: always()
@@ -99,7 +101,7 @@ jobs:
         with:
           name: flutter-device-smoke-ios-${{ github.run_id }}
           path: |
-            artifacts/ios-no-login-smoke.log
+            artifacts/ios-no-login-smoke.log*
             artifacts/*diagnose*.tar.gz
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/single-account-nightly.yml
+++ b/.github/workflows/single-account-nightly.yml
@@ -114,8 +114,10 @@ jobs:
 
       - name: Collect iOS diagnostics after failure
         if: failure()
-        # --output expects a directory; the archive name is generated.
-        run: xcrun simctl diagnose -b --output artifacts || true
+        # Xcode 26 simctl only accepts --output=<path> (equals form) and
+        # pauses on an interactive "Press ENTER" prompt unless stdin is fed.
+        # The archive is written as <path>.tar.gz next to the given path.
+        run: echo | xcrun simctl diagnose -b --output=artifacts/diagnose || true
 
       - name: Remove protected test configuration
         if: always()
@@ -127,7 +129,7 @@ jobs:
         with:
           name: flutter-single-account-ios-${{ github.run_id }}
           path: |
-            artifacts/ios-single-account.log
+            artifacts/ios-single-account.log*
             artifacts/*diagnose*.tar.gz
           if-no-files-found: warn
           retention-days: 7

--- a/tool/ci/run_ios_simulator_test.sh
+++ b/tool/ci/run_ios_simulator_test.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 # Runs a flutter integration test on a booted iOS simulator with a watchdog.
-# `flutter test` can hang forever while discovering the Dart VM Service (seen
-# on iOS 26 simulators), so the test process is killed after WATCHDOG_SECONDS
-# and the step fails normally, letting the diagnose step collect evidence
-# instead of the whole job timing out with nothing.
+#
+# On iOS 26 simulators `flutter test` sometimes never discovers the Dart VM
+# Service of the launched app: it prints "0 tests passed" right after the
+# Xcode build and then never exits. Two defenses against that flake:
+#   1. the attempt is killed as soon as the log shows "0 tests passed"
+#      (or when it exceeds WATCHDOG_SECONDS), so the step fails fast instead
+#      of hanging until the job timeout;
+#   2. a zero-test attempt is retried once with a freshly rebooted simulator.
+# If the retry also fails, the step fails normally and the diagnose step in
+# the workflow collects evidence.
 set -euo pipefail
 
 test_target="${1:?usage: run_ios_simulator_test.sh TEST_TARGET LOG_NAME}"
 log_name="${2:?usage: run_ios_simulator_test.sh TEST_TARGET LOG_NAME}"
 watchdog_seconds="${WATCHDOG_SECONDS:-720}"
+max_attempts="${MAX_ATTEMPTS:-2}"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 mkdir -p "$repo_root/artifacts"
@@ -27,25 +34,77 @@ if [[ -n "${E2E_CONFIG_PATH:-}" ]]; then
   command+=(--dart-define-from-file="$E2E_CONFIG_PATH")
 fi
 
-"${command[@]}" >"$log_file" 2>&1 &
-test_pid=$!
-(
-  sleep "$watchdog_seconds"
-  echo "Watchdog: flutter test exceeded ${watchdog_seconds}s, killing it" >&2
-  kill -TERM "$test_pid" 2>/dev/null || true
-  sleep 15
-  kill -KILL "$test_pid" 2>/dev/null || true
-) &
-watchdog_pid=$!
+# Runs one attempt in the background and watches its log: kills the test
+# when it reports 0 tests (VM service never discovered, process would hang
+# forever) or when it exceeds the watchdog timeout.
+run_attempt() {
+  local attempt_log="$1"
+  "${command[@]}" >"$attempt_log" 2>&1 &
+  local test_pid=$!
+  (
+    elapsed=0
+    while kill -0 "$test_pid" 2>/dev/null; do
+      if grep -qF "0 tests passed" "$attempt_log" 2>/dev/null; then
+        echo "Watchdog: flutter test found 0 tests (VM service not discovered); killing it" >&2
+        kill -TERM "$test_pid" 2>/dev/null || true
+        sleep 15
+        kill -KILL "$test_pid" 2>/dev/null || true
+        break
+      fi
+      if (( elapsed >= watchdog_seconds )); then
+        echo "Watchdog: flutter test exceeded ${watchdog_seconds}s; killing it" >&2
+        kill -TERM "$test_pid" 2>/dev/null || true
+        sleep 15
+        kill -KILL "$test_pid" 2>/dev/null || true
+        break
+      fi
+      sleep 5
+      elapsed=$((elapsed + 5))
+    done
+  ) &
+  local watchdog_pid=$!
+  local status=0
+  wait "$test_pid" || status=$?
+  # Reap the watchdog so bash does not print a "Terminated" job notice.
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+  return "$status"
+}
 
 status=0
-wait "$test_pid" || status=$?
-# Reap the watchdog so bash does not print a "Terminated" job notice.
-kill "$watchdog_pid" 2>/dev/null || true
-wait "$watchdog_pid" 2>/dev/null || true
+attempt=1
+while (( attempt <= max_attempts )); do
+  if (( attempt == 1 )); then
+    attempt_log="$log_file"
+  else
+    attempt_log="$log_file.attempt$attempt"
+    echo "Rebooting simulator before attempt $attempt" >&2
+    xcrun simctl shutdown "$simulator_udid" 2>/dev/null || true
+    xcrun simctl boot "$simulator_udid"
+    xcrun simctl bootstatus "$simulator_udid" -b >&2
+  fi
+  echo "Attempt $attempt of $max_attempts"
+  status=0
+  run_attempt "$attempt_log" || status=$?
+  if [[ "$status" -eq 0 ]]; then
+    break
+  fi
+  if (( attempt < max_attempts )) && grep -qF "0 tests passed" "$attempt_log"; then
+    echo "Retrying: attempt $attempt discovered 0 tests (flaky VM service discovery on iOS 26 simulators)" >&2
+    attempt=$((attempt + 1))
+  else
+    break
+  fi
+done
 
 cat "$log_file"
+for extra_log in "$log_file".attempt*; do
+  if [[ -e "$extra_log" ]]; then
+    echo "=== retry log: $extra_log ==="
+    cat "$extra_log"
+  fi
+done
 if [[ "$status" -ne 0 ]]; then
-  echo "iOS simulator test failed or was killed by the ${watchdog_seconds}s watchdog" >&2
+  echo "iOS simulator test failed or was killed by the watchdog" >&2
 fi
 exit "$status"


### PR DESCRIPTION
flutter test on iOS 26 simulators sometimes never discovers the Dart VM Service: it prints "0 tests passed" right after the Xcode build and then hangs forever. Kill the attempt as soon as the log shows zero tests (instead of waiting for the full watchdog timeout) and retry once with a freshly rebooted simulator. Real test failures never trigger a retry.

Also fix the diagnose step: Xcode 26 simctl only accepts the equals form of --output and pauses on an interactive 'Press ENTER' prompt unless stdin is fed, so the step used to exit instantly with no archive. Upload retry logs alongside the main one.