### PR TITLE
fix(ci): cache iOS SPM dependencies and narrow zero-test detection

### DIFF
--- a/.github/workflows/device-smoke.yml
+++ b/.github/workflows/device-smoke.yml
@@ -85,6 +85,20 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Cache Swift Package Manager dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        # iOS dependencies resolve via SPM (no CocoaPods in this repo). Their
+        # binary targets download from download.shengwang.cn, which has timed
+        # out from GitHub runners and failed the job before any test ran.
+        # Caching the SPM stores removes that network dependency once fetched.
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData/*/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', 'im_flutter_sdk/example/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Run no-login smoke on iOS simulator
         run: ./tool/ci/run_ios_simulator_test.sh integration_test/no_login_presence_test.dart ios-no-login-smoke.log
 

--- a/.github/workflows/single-account-nightly.yml
+++ b/.github/workflows/single-account-nightly.yml
@@ -109,6 +109,20 @@ jobs:
           ./tool/ci/write_e2e_dart_defines.sh "$RUNNER_TEMP/flutter-single-account.json"
           echo "E2E_CONFIG_PATH=$RUNNER_TEMP/flutter-single-account.json" >> "$GITHUB_ENV"
 
+      - name: Cache Swift Package Manager dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        # iOS dependencies resolve via SPM (no CocoaPods in this repo). Their
+        # binary targets download from download.shengwang.cn, which has timed
+        # out from GitHub runners and failed the job before any test ran.
+        # Caching the SPM stores removes that network dependency once fetched.
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData/*/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.swift', 'im_flutter_sdk/example/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Run login and local database suite on iOS simulator
         run: ./tool/ci/run_ios_simulator_test.sh integration_test/single_account_local_test.dart ios-single-account.log
 

--- a/tool/ci/run_ios_simulator_test.sh
+++ b/tool/ci/run_ios_simulator_test.sh
@@ -2,9 +2,9 @@
 # Runs a flutter integration test on a booted iOS simulator with a watchdog.
 #
 # On iOS 26 simulators `flutter test` sometimes never discovers the Dart VM
-# Service of the launched app: it prints "0 tests passed" right after the
+# Service of the launched app: it prints "0 tests passed." right after the
 # Xcode build and then never exits. Two defenses against that flake:
-#   1. the attempt is killed as soon as the log shows "0 tests passed"
+#   1. the attempt is killed as soon as the log shows "0 tests passed."
 #      (or when it exceeds WATCHDOG_SECONDS), so the step fails fast instead
 #      of hanging until the job timeout;
 #   2. a zero-test attempt is retried once with a freshly rebooted simulator.
@@ -44,7 +44,9 @@ run_attempt() {
   (
     elapsed=0
     while kill -0 "$test_pid" 2>/dev/null; do
-      if grep -qF "0 tests passed" "$attempt_log" 2>/dev/null; then
+      # Match "0 tests passed." exactly: the VM-service flake ends the line
+      # with a period, while a real failure prints "0 tests passed, N failed."
+      if grep -qE "0 tests passed\." "$attempt_log" 2>/dev/null; then
         echo "Watchdog: flutter test found 0 tests (VM service not discovered); killing it" >&2
         kill -TERM "$test_pid" 2>/dev/null || true
         sleep 15
@@ -89,7 +91,7 @@ while (( attempt <= max_attempts )); do
   if [[ "$status" -eq 0 ]]; then
     break
   fi
-  if (( attempt < max_attempts )) && grep -qF "0 tests passed" "$attempt_log"; then
+  if (( attempt < max_attempts )) && grep -qE "0 tests passed\." "$attempt_log"; then
     echo "Retrying: attempt $attempt discovered 0 tests (flaky VM service discovery on iOS 26 simulators)" >&2
     attempt=$((attempt + 1))
   else


### PR DESCRIPTION
iOS jobs download Swift Package Manager dependencies on every run, including binary targets hosted on download.shengwang.cn, which has timed out from GitHub runners and failed the job before any test ran. Cache the global SPM store and per-project SourcePackages keyed on Package.swift and the example pubspec.lock so the network fetch only happens when dependencies change.

Also tighten the VM-service flake detection in run_ios_simulator_test.sh: the flaky hang prints "0 tests passed." while a real failure (e.g. an SPM resolution error) prints "0 tests passed, N failed.". The previous substring match misclassified the latter as the flake and burned the single retry on a failure mode that retrying cannot fix.