### PR TITLE
feat: add release APK E2E automation (skill + CI + config injection)

### DIFF
--- a/.doc/specs/release-test-automation/design.md
+++ b/.doc/specs/release-test-automation/design.md
@@ -1,0 +1,145 @@
+# release APK 测试自动化设计
+
+## Overview
+
+让 `im_flutter_test` 能以 release 模式稳定构建运行，并在启动时自动连接 WebSocket 桥接，消除手动 UI 操作；同时提供一个 repo-local skill 把「构建 → 模拟器 → 安装 → 桥接 → pytest → 报告」串成一条命令，降低团队上手门槛。
+
+方案 A（选定）：`config.yaml` 继续打包进 APK asset，改 `sdk_options`/`websocket` 后需重新构建 APK；`rest_api`/`topics` 由 Python 侧运行时读取，不重建。skill 内包含构建步骤。运行时读取外部文件（方案 B）留待出现多环境痛点时再做。
+
+## Architecture
+
+### 1. release 构建支持（已完成）
+
+- `im_flutter_test/android/app/proguard-rules.pro`
+  - 新增 `-dontwarn` 忽略厂商推送（OPPO/魅族/vivo/小米）可选依赖的缺失类。
+  - 新增 `-keep class com.hyphenate.**` 与 `-keep class internal.com.getkeepsafe.relinker.**`：环信 jar 未自带 consumer rules，其原生库按类名 JNI 查找 `com.hyphenate.chat.adapter.**` 等类，混淆会触发 `ClassNotFoundException`。
+- `im_flutter_test/android/app/build.gradle`
+  - release buildType 增加 `proguardFiles ... 'proguard-rules.pro'`。
+
+### 2. App 自动连接（双端）
+
+- `im_flutter_test/lib/sdk_config_loader.dart`
+  - 复用现有 `rootBundle.loadString('assets/config.yaml')` 读取方式，新增读取 `websocket` 节的方法（返回 `base_url`、`default_topic`），缺失时回退默认值。
+  - 新增按设备读取 topic 的方法：`topics[device]`，缺失回退 `default_topic`。
+- `im_flutter_test/lib/websocket_config_page.dart`
+  - 设备标识通过编译期常量 `String.fromEnvironment('DEVICE', defaultValue: 'deviceA')` 确定。
+  - `initState` 异步读取 websocket 配置，按设备解析 topic，填充 controller，并自动调用 `_connect()`。
+  - 保留手动「连接/断开」按钮与日志列表，用于诊断与手动切换。
+- 默认值常量 `kDefaultBridgeWebSocketBaseUrl` / `kDefaultBridgeWebSocketTopic` 保持不变，作为回退来源。
+- 双端通过构建两个 APK 实现：`--dart-define=DEVICE=deviceA` 与 `--dart-define=DEVICE=deviceB`，分别安装到两台模拟器。
+
+### 3. 一键 skill
+
+- `native-auto-test/skills/im-flutter-run/`
+  - `SKILL.md`：使用说明、最小依赖（无需 Android Studio）、配置生效规则。
+  - `scripts/run.sh`：环境检测 → 构建两个 release APK（deviceA/deviceB）→ 启动两台模拟器 → 分别安装 → 复用 `make ws-bridge-up`（relay + reverse）→ 复用 `make test-local`（pytest）→ `allure generate` 出报告。
+- 复用现有组件，不重复实现：
+  - relay/reverse/env：`make ws-bridge-up` → `scripts/ws_bridge_local.sh` + `scripts/adb_reverse_ws_bridge.sh`
+  - pytest：`make test-local`（加载 `.local/ws-bridge.env`）
+  - 报告：`allure generate out/allure-results -o out/allure-report --clean`
+
+## Sequence Diagrams
+
+### 自动连接（App 启动）
+
+```mermaid
+sequenceDiagram
+    participant M as main()
+    participant L as SdkConfigLoader
+    participant P as WebSocketConfigPage
+    participant B as IMWebSocketBridge
+    participant R as Local relay
+
+    M->>L: loadOptions() 读 sdk_options 初始化 SDK
+    M->>P: runApp -> initState
+    P->>L: 读 websocket.base_url / default_topic
+    L-->>P: url + topic（缺失则默认值）
+    P->>B: start(url?topic=..., deviceName=deviceA)
+    B->>R: WebSocket connect
+    R-->>B: 已连接
+    P->>P: registerAllHandlers()
+```
+
+### 一键 skill 流程
+
+```mermaid
+sequenceDiagram
+    participant U as 协作者
+    participant S as run.sh
+    participant F as flutter build
+    participant E as emulator
+    participant M as make ws-bridge-up
+    participant T as make test-local
+    participant A as allure
+
+    U->>S: 一键执行
+    S->>S: 检测 flutter/adb/emulator/python/AVD
+    S->>F: flutter build apk --release
+    S->>E: 启动模拟器（headless）等待 boot
+    S->>E: adb install app-release.apk
+    S->>M: relay + adb reverse + .local env
+    S->>E: adb shell am start（App 自动连接）
+    S->>T: pytest（加载本地 WS 地址）
+    S->>A: allure generate 报告
+    S-->>U: 输出报告路径
+```
+
+## Component and Data Design
+
+### websocket 配置读取
+
+`sdk_config_loader.dart` 新增方法（示意）：
+
+```dart
+static Future<WebSocketConfig> loadWebSocketConfig() async {
+  final content = await rootBundle.loadString('assets/config.yaml');
+  final yaml = loadYaml(content) as YamlMap;
+  final ws = yaml['websocket'] as YamlMap?;
+  final baseUrl = ws?['base_url']?.toString().trim();
+  final topic = ws?['default_topic']?.toString().trim();
+  return WebSocketConfig(
+    baseUrl: (baseUrl == null || baseUrl.isEmpty)
+        ? kDefaultBridgeWebSocketBaseUrl
+        : baseUrl,
+    topic: (topic == null || topic.isEmpty)
+        ? kDefaultBridgeWebSocketTopic
+        : topic,
+  );
+}
+```
+
+`websocket_config_page.dart` 的 `initState` 变为异步初始化：先填充 controller，再触发一次 `_connect()`。`_connect()` 复用现有逻辑（`IMWebSocketBridge.instance.start` + `EventBridgeHandler.instance.registerAllHandlers()`），连接失败时沿用现有 SnackBar 提示，不阻塞 UI。
+
+### skill 脚本职责与边界
+
+`run.sh` 只做编排，具体命令复用现有 Makefile target：
+
+| 步骤 | 复用/新增 |
+|---|---|
+| 环境检测 | 新增（command -v 检查 + AVD 列表） |
+| 构建 release APK | 新增 `cd im_flutter_test && flutter build apk --release` |
+| 启动模拟器 | 新增（`emulator -avd <avd> -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -no-snapshot`） |
+| 安装 + 启动 App | 新增 `adb install` + `adb shell am start` |
+| relay + reverse | 复用 `make ws-bridge-up` |
+| pytest | 复用 `make test-local ARGS=...` |
+| 报告 | 新增 `allure generate` |
+
+skill 不自动修改 `config.yaml`、REST 配置或业务账号；不改写现有 relay 的 PID/env 状态文件语义。
+
+## Constraints and Tradeoffs
+
+- 只改 `im_flutter_test` 与 `native-auto-test`，不触碰 `im_flutter_sdk` 发布层与 iOS。
+- 方案 A：config.yaml 打包进 APK，改 `sdk_options`/`websocket`/`topics` 需重建 APK。代价是 APK 不通用；收益是改动小、链路简单。运行时读取（方案 B）留作后续。
+- 双端通过 `--dart-define=DEVICE=...` 构建两个 APK，代价是构建两次（release 增量构建快）；收益是无需改原生层读 intent、一个代码库覆盖双端。
+- `-keep class com.hyphenate.**` 放弃对环信 SDK 的混淆优化（包体积略增），换取 JNI/反射/序列化稳定性；对测试 App 可接受。
+- skill 首期不处理「无人值守重启模拟器失败重试」「多套环境并行」，聚焦双端一键跑通。
+- 不引入新生产依赖；skill 仅依赖已有的 flutter/adb/emulator/python/allure。
+
+## Testing Strategy
+
+1. 对 `sdk_config_loader.dart` 的 websocket 配置读取与回退逻辑编写 Dart 单元测试（复用现有 `test/` 目录模式），覆盖：正常值、缺失节、空字符串回退。
+2. 对自动连接触发逻辑做静态验证与模拟器冒烟：启动 relay 后装 release APK，无需手动操作，pytest 能收到 App 的连接并完成一次 `api.call`。
+3. release 构建与 SDK 初始化：`flutter build apk --release` 成功后，logcat 验证 `hyphenate SDK is initialized`、无 `ClassNotFoundException`/`FATAL`。
+4. skill：在本地完整执行 `run.sh`，验证一键走完「构建→模拟器→安装→桥接→pytest→报告」；再验证缺失 flutter/adb 时快速失败并给出提示。
+5. 回归：确认现有 `make ws-bridge-up/down/test-local` 行为不变；`tests/tools` 无设备测试仍通过。
+6. 手工验收项：release 构建、模拟器端到端、skill 一键流程（需显式 Android 环境）。

--- a/.doc/specs/release-test-automation/requirements.md
+++ b/.doc/specs/release-test-automation/requirements.md
@@ -1,0 +1,33 @@
+# release APK 测试自动化
+
+## User Story
+
+作为 Flutter SDK E2E 测试维护者，我希望 `im_flutter_test` 能以 release 模式构建并正常运行，从而用接近生产的形态（AOT + 混淆）跑 E2E 用例，同时让本地运行更快、更稳定。
+
+作为仓库协作者，我希望测试 App 启动后自动连接 `native-auto-test/config.yaml` 中配置的 WebSocket 桥接，从而无需在模拟器上手动填写 URL/topic/device 并点击「连接」，支持无人值守和后续 CI/远程运行。
+
+作为团队其他成员，我希望通过一个 repo-local skill 一条命令完成「构建 release APK → 启动模拟器 → 安装 App → 配置桥接 → 运行 pytest → 生成报告」，从而无需手动搭建 Flutter/Android 环境、无需启动 Android Studio。
+
+## Acceptance Criteria（EARS）
+
+1. 当在 `im_flutter_test` 中执行 `flutter build apk --release` 时，系统应成功产出 `build/app/outputs/flutter-apk/app-release.apk`，且环信 SDK 引用的可选厂商推送依赖（OPPO/魅族/vivo/小米）缺失不得导致 R8 构建失败。
+2. 当 release APK 在模拟器上启动时，App 应无崩溃地完成 SDK 初始化，环信 SDK 版本日志应正常输出，`com.hyphenate.chat.adapter.**` 等 JNI 桥接类不得因 R8 混淆改名而触发 `ClassNotFoundException`。
+3. 当 App 启动时，系统应从打包进 asset 的 `config.yaml` 读取 `websocket.base_url` 与 `websocket.default_topic`，并自动建立 WebSocket 桥接连接、注册事件处理器，无需任何手动 UI 操作。
+4. 当 `config.yaml` 存在 `websocket.base_url` 与 `websocket.default_topic` 时，App 应优先使用该配置值；当缺失或为空时，系统应回退到现有默认值 `ws://127.0.0.1:4000/iov/websocket/dual` 与 `adc`，不得因缺失配置而崩溃。
+5. 当 App 自动连接成功后，UI 应仍保留 URL/topic/device 输入与手动「连接/断开」能力，便于诊断时手动重连或切换环境，不得因自动连接移除现有手动入口。
+6. 当自动连接失败（如 relay 未启动）时，App 应在 UI 上给出可定位的失败提示，且不阻塞后续手动重连；不得静默失败。
+7. 当协作者执行一键 skill 时，系统应先检测 flutter、adb、emulator、python 与可用 AVD，任一缺失或不可执行时应立即给出明确修复提示并非零退出，不得进入后续步骤。
+8. 当环境检测通过时，skill 应按顺序自动完成 release APK 构建、模拟器启动、APK 安装、WebSocket relay 启动、`adb reverse` 端口映射、pytest 运行与报告生成，全程无需启动 Android Studio 或手动操作 App。
+9. 当 skill 复用现有 `make ws-bridge-up` / `make test-local` 能力时，relay 启动、reverse 映射与本地 pytest 环境加载行为应保持不变，不重复实现已有逻辑。
+10. 当 pytest 运行结束时，skill 应生成报告并输出可访问的报告路径/URL；报告内容应包含请求、响应与比对结果（复用现有 allure/pytest-html 能力）。
+11. 当协作者按 skill 文档操作时，文档应明确说明「改 `sdk_options`/`websocket` 后需重新构建 APK、`rest_api`/`topics` 无需重建」的配置生效规则，以及无需安装 Android Studio 的最小依赖。
+12. 当本功能完成时，自动化测试应覆盖 config.yaml 的 websocket 配置读取、缺失回退与自动连接触发逻辑，且不依赖真实设备或外部服务器；release 构建与模拟器端到端流程作为需显式设备环境的手工验收步骤。
+13. 当以 `--dart-define=DEVICE=deviceB` 构建 release APK 时，App 应使用 `topics.deviceB` 作为 topic、`deviceB` 作为设备标识；未指定 `DEVICE` 时默认 `deviceA`，不得破坏单端行为。
+14. 当 `topics` 节缺失对应设备或为空时，App 应回退到 `websocket.default_topic`，保证单端/无 topics 配置下仍可连接。
+15. 当业务 cases 执行时，session 登录应成功登录 deviceA 与 deviceB 两台设备，且至少一个真实业务 case（如 client 连接态查询）应通过，作为本功能完成的可运行验收标准。
+
+## 范围说明
+
+- 只改 `im_flutter_test`（测试端）与 `native-auto-test`（skill），不修改 `im_flutter_sdk` 发布层。
+- 自动连接支持**双端**（deviceA/deviceB 两台设备分别连 `topics.deviceA`/`topics.deviceB`），以满足业务 cases 的 session 双端登录要求。
+- GitHub Release 发布 APK 与远程机器/Docker 运行不在本 spec 内，作为后续独立功能。

--- a/.doc/specs/release-test-automation/tasks.md
+++ b/.doc/specs/release-test-automation/tasks.md
@@ -1,0 +1,132 @@
+# release APK 测试自动化实施计划
+
+> **执行要求：** 按本文件逐项实施，本文件是唯一任务状态来源，不创建额外 implementation plan。未经用户明确要求，不提交、不推送 Git。
+
+**目标：** 让 `im_flutter_test` 以 release 模式稳定构建运行并启动自动连接，提供 repo-local 一键 skill 串起「构建→模拟器→安装→桥接→pytest→报告」。
+
+**架构：** release 通过 proguard keep 规则保留环信 SDK；App 复用 `rootBundle` 读 config.yaml 的 `websocket` 节并在 initState 自动连接；skill 复用 `make ws-bridge-up` / `make test-local`，仅编排新增的构建、模拟器、安装、报告步骤。
+
+**技术栈：** Flutter/Dart 3.5、Android Gradle R8、Bash、Python pytest、allure。
+
+## 全局约束
+
+- 只改 `im_flutter_test`（测试端）与 `native-auto-test`（skill），不修改 `im_flutter_sdk` 发布层。
+- 不引入新生产依赖；不自动修改 `config.yaml`、REST 配置或业务账号。
+- 自动连接默认单端 `deviceA`；多端自动连接不在本 spec。
+- release 保留 debug 签名（沿用现有 `signingConfig = signingConfigs.debug`），仅用于内部测试。
+- 未经用户明确要求，不执行 `git commit`/`push`。
+
+---
+
+## Task 1：release 构建支持（proguard keep 规则）
+
+**Files**
+
+- Create: `im_flutter_test/android/app/proguard-rules.pro`
+- Edit: `im_flutter_test/android/app/build.gradle`
+
+**Interfaces**
+
+- 新增 `-dontwarn` 忽略厂商推送（OPPO/魅族/vivo/小米）可选依赖。
+- 新增 `-keep class com.hyphenate.** { *; }` 与 `-keep class internal.com.getkeepsafe.relinker.** { *; }`。
+- release buildType 引用 `proguard-rules.pro`。
+
+- [x] 创建 `proguard-rules.pro`，含厂商推送 `-dontwarn` 与环信/ReLinker `-keep` 规则。
+- [x] `build.gradle` release buildType 增加 `proguardFiles`。
+- [x] `flutter build apk --release` 构建通过（58.9MB）。
+- [x] 模拟器验证：无 `ClassNotFoundException`/`FATAL`，`hyphenate SDK is initialized with version: 4.23.0` 日志正常。
+
+---
+
+## Task 2：App 自动连接（读 config.yaml 的 websocket 节）
+
+**Files**
+
+- Edit: `im_flutter_test/lib/sdk_config_loader.dart`
+- Edit: `im_flutter_test/lib/websocket_config_page.dart`
+- Create: `im_flutter_test/test/sdk_config_loader_websocket_test.dart`（如可无设备测）
+
+**Interfaces**
+
+- `SdkConfigLoader` 新增读取 `websocket.base_url` / `websocket.default_topic` 的方法，缺失回退 `kDefaultBridgeWebSocketBaseUrl` / `kDefaultBridgeWebSocketTopic`。
+- `WebSocketConfigPage.initState` 异步读取配置、填充 controller 并自动 `_connect()`；保留手动连接/断开。
+
+- [x] 在 `sdk_config_loader.dart` 新增 `loadWebSocketConfig()` + `parseWebSocketConfig()`（纯函数），空值回退默认常量。
+- [x] 在 `websocket_config_page.dart` 的 `initState` 异步加载配置、填充 controller、自动触发一次 `_connect()`（device 默认 `deviceA`）。
+- [x] 连接失败沿用现有 SnackBar 提示，不阻塞手动重连。
+- [x] 为配置读取与回退逻辑补充单元测试（缺失节、空字符串、正常值、非法 yaml、去空白）。
+- [x] `flutter analyze` 通过（仅 2 个既有 deprecation info）。
+- [x] 模拟器冒烟：release APK 启动后自动以 topic=adc 连接 relay，探针请求返回响应（isLoggedInBefore -> false）。
+
+---
+
+## Task 3：一键 skill
+
+**Files**
+
+- Create: `native-auto-test/skills/im-flutter-run/SKILL.md`
+- Create: `native-auto-test/skills/im-flutter-run/scripts/run.sh`
+
+**Interfaces**
+
+- `run.sh` 步骤：检测环境 → 构建 release APK → 启动模拟器 → 安装 → `make ws-bridge-up` → 启动 App → `make test-local ARGS=...` → `allure generate`。
+- 环境检测项：flutter、adb、emulator、python、至少一个 AVD；缺失时非零退出并提示。
+
+- [x] 编写 `run.sh`：环境检测（command -v + `emulator -list-avds`），失败快速退出并给出修复提示。
+- [x] 构建步骤：`cd im_flutter_test && flutter build apk --release`。
+- [x] 模拟器步骤：`emulator -avd <avd> -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -no-snapshot`，等待 `sys.boot_completed=1`。
+- [x] 安装步骤：`adb install -r app-release.apk`。
+- [x] 桥接步骤：复用 `make ws-bridge-up`（relay + reverse + env）。
+- [x] 启动 App：`adb shell am start -n com.easemob.im_flutter_test/.MainActivity`（App 自动连接）。
+- [x] 用例步骤：复用 `make test-local ARGS="$@"`，并自动加 `--alluredir=out/allure-results`。
+- [x] 报告步骤：`allure generate out/allure-results -o out/allure-report --clean` 并输出路径。
+- [x] 编写 `SKILL.md`（英文）与 `openai.yaml`：最小依赖（无需 Android Studio）、用法、config 生效规则。
+- [x] skill 校验：`quick_validate.py` 通过（Skill is valid!）。
+- [x] `run.sh` 全英文化，无中文残留；`bash -n` 语法检查通过。
+
+---
+
+## Task 4：验证与文档
+
+- [x] 本地一键 `run.sh` 全流程跑通（build→模拟器→安装→桥接→pytest→报告），无需手动操作 App、无需 Android Studio。
+- [x] 验证 `make ws-bridge-up/down/test-local` 行为不变；`tests/tools` 无设备测试仍通过（40 passed）。
+- [x] 回归确认 `flutter build apk --debug` 未受影响（构建通过）。
+- [x] 更新 `native-auto-test/README.md` 补充 skill 入口。
+- [x] 更新本 tasks.md 完成状态。
+
+---
+
+## Task 5：双端支持（deviceA/deviceB）
+
+**Files**
+
+- Edit: `im_flutter_test/lib/sdk_config_loader.dart`
+- Edit: `im_flutter_test/lib/websocket_config_page.dart`
+- Edit: `im_flutter_test/test/sdk_config_loader_websocket_test.dart`
+- Edit: `native-auto-test/skills/im-flutter-run/scripts/run.sh`
+
+**Interfaces**
+
+- 设备标识通过 `String.fromEnvironment('DEVICE', defaultValue: 'deviceA')` 确定。
+- topic 解析优先级：`topics[device]` > `websocket.default_topic` > 默认常量。
+- `run.sh` 构建两个 APK（`--dart-define=DEVICE=deviceA/deviceB`）并启动两台模拟器分别安装。
+
+- [x] `sdk_config_loader.dart` 新增 `loadTopicForDevice(device)` / `parseTopicForDevice(content, device)`。
+- [x] `websocket_config_page.dart` 用 `DEVICE` 编译常量决定 device，按 device 解析 topic，自动连接。
+- [x] 补充 `parseTopicForDevice` 单元测试（6 个新用例：有值/缺失/空/非法 yaml/去空白）。
+- [x] `run.sh` 支持两台模拟器：构建两个 APK，分别安装到 AVD1/AVD2（固定 adb 端口 5554/5556）。
+- [x] `flutter analyze`（仅 2 个既有 info）与 `flutter test`（12 个用例）通过。
+
+---
+
+## Task 6：业务 cases 端到端验收
+
+- [x] 启动两台模拟器，分别安装 deviceA/deviceB APK，确认均自动连接对应 topic。
+- [x] 跑真实业务 case `tests/client/test_client.py::test_client_get_current_user`，session 双端登录成功、case 通过（1 passed）。
+- [x] 确认 `make ws-bridge-up` 对两台模拟器均完成 reverse（emulator-5554 + emulator-5556）。
+
+---
+
+## 验收对照
+
+对应 requirements.md 的 EARS 1-15 条，逐项确认后在本节勾选。

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,75 @@
+name: Build Release APK
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v1.0.0); leave empty for manual run'
+        required: false
+        default: ''
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.5'
+          channel: stable
+
+      - name: Switch Android SDK to remote maven dependency
+        # CI 检出代码没有 gitignore 的本地 jar/so，切到远程 maven（同版本 4.23.0）。
+        run: |
+          cd im_flutter_sdk_android/android
+          sed -i "s|jniLibs.srcDirs = \['./libs/easemob-sdk/libs'\]|// jniLibs.srcDirs = ['./libs/easemob-sdk/libs']|" build.gradle
+          sed -i "s|implementation files('./libs/easemob-sdk/libs/hyphenatechat_.*\.jar')|// implementation files('./libs/easemob-sdk/libs/hyphenatechat_local.jar')|" build.gradle
+          sed -i "s|// implementation 'io.hyphenate:hyphenate-chat:.*'|implementation 'io.hyphenate:hyphenate-chat:4.23.0'|" build.gradle
+          echo "--- 切换后 dependencies ---"
+          grep -nE "hyphenate|jniLibs" build.gradle
+
+      - name: Build deviceA release APK
+        run: |
+          cd im_flutter_test
+          flutter pub get
+          flutter build apk --release --dart-define=DEVICE=deviceA
+          cp build/app/outputs/flutter-apk/app-release.apk app-release-deviceA.apk
+
+      - name: Build deviceB release APK
+        run: |
+          cd im_flutter_test
+          flutter build apk --release --dart-define=DEVICE=deviceB
+          cp build/app/outputs/flutter-apk/app-release.apk app-release-deviceB.apk
+
+      - name: Package test framework
+        run: |
+          tar -czf native-auto-test.tar.gz native-auto-test \
+            --exclude='native-auto-test/.flutter-vnev' \
+            --exclude='native-auto-test/.venv' \
+            --exclude='native-auto-test/.local' \
+            --exclude='native-auto-test/out' \
+            --exclude='native-auto-test/.pytest_cache' \
+            --exclude='native-auto-test/__pycache__' \
+            --exclude='native-auto-test/config.yaml'
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          files: |
+            im_flutter_test/app-release-deviceA.apk
+            im_flutter_test/app-release-deviceB.apk
+            native-auto-test.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/im_flutter_test/android/app/build.gradle
+++ b/im_flutter_test/android/app/build.gradle
@@ -35,6 +35,8 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
+            // 环信 SDK 引用的可选厂商推送依赖缺失，加 dontwarn 规则让 R8 通过。
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/im_flutter_test/android/app/proguard-rules.pro
+++ b/im_flutter_test/android/app/proguard-rules.pro
@@ -1,0 +1,18 @@
+# 环信 SDK 的 push 模块引用了可选的厂商推送 SDK（OPPO/魅族/vivo/小米）。
+# 本测试工程未集成这些厂商推送依赖，release 构建时 R8 会报 Missing class。
+# 这些类仅在对应厂商推送场景才被调用，本项目不用推送，忽略是安全的。
+-dontwarn com.heytap.msp.push.**
+-dontwarn com.meizu.cloud.pushsdk.**
+-dontwarn com.vivo.push.**
+-dontwarn com.xiaomi.mipush.sdk.**
+
+# 环信 SDK 的 jar 未自带 consumer proguard 规则，但其原生库（libhyphenate.so 等）
+# 通过 JNI 按类名查找 com.hyphenate.chat.adapter.** 等 Java 类，R8 混淆改名会导致
+# ClassNotFoundException 崩溃（实测：EMAREncryptUtils）。
+# 整体保留环信 SDK，不做混淆。
+-keep class com.hyphenate.** { *; }
+-dontwarn com.hyphenate.**
+
+# ReLinker（原生库加载器）也通过反射加载 so，保留避免混淆破坏。
+-keep class internal.com.getkeepsafe.relinker.** { *; }
+-dontwarn internal.com.getkeepsafe.relinker.**

--- a/im_flutter_test/lib/sdk_config_loader.dart
+++ b/im_flutter_test/lib/sdk_config_loader.dart
@@ -1,18 +1,37 @@
+import 'dart:io';
+
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:im_flutter_sdk/im_flutter_sdk.dart';
 import 'package:yaml/yaml.dart';
 
-/// 从 assets/config.yaml（软链到 native-auto-test/config.yaml）的 sdk_options 节
-/// 读取配置并构建 EMOptions。
+/// 外部配置文件路径（adb push 到 App 的 external files dir）。
+/// 用于“启动传入配置”：改配置无需重新打包 APK，直接把 config.yaml 推入该路径即可。
+const String kExternalConfigPath =
+    '/sdcard/Android/data/com.easemob.im_flutter_test/files/config.yaml';
+
+/// 读取 config.yaml 配置并构建 EMOptions。
 ///
-/// 运行时直接从 asset 读取，无需代码生成步骤。
-/// 修改 native-auto-test/config.yaml 后重新编译即可生效。
+/// 优先级：外部文件（启动传入） > 打包 asset（assets/config.yaml）。
+/// 这样 release APK 可复用，配置由运行时推入，无需重新编译。
 class SdkConfigLoader {
   SdkConfigLoader._();
 
-  /// 异步加载 config.yaml asset 并构建 EMOptions。
+  /// 读取 config.yaml 内容：优先外部文件，缺失/失败回退打包 asset。
+  static Future<String> _loadConfigContent() async {
+    final file = File(kExternalConfigPath);
+    try {
+      if (await file.exists()) {
+        return await file.readAsString();
+      }
+    } catch (_) {
+      // 外部文件读取失败，回退 asset。
+    }
+    return rootBundle.loadString('assets/config.yaml');
+  }
+
+  /// 异步加载 config.yaml 并构建 EMOptions。
   static Future<EMOptions> loadOptions() async {
-    final content = await rootBundle.loadString('assets/config.yaml');
+    final content = await _loadConfigContent();
     final yaml = loadYaml(content) as YamlMap;
     final sdkOpts = yaml['sdk_options'] as YamlMap?;
 
@@ -42,6 +61,45 @@ class SdkConfigLoader {
       enableAutoSyncContacts: _bool(sdkOpts, 'enable_auto_sync_contacts', false),
       enableUserInfo: _boolNullable(sdkOpts, 'enable_user_info'),
     );
+  }
+
+  /// 从 config.yaml 的 websocket 节读取桥接配置。
+  /// 返回可空字段：缺失/空/解析失败时返回 null，由调用方回退默认值。
+  static Future<({String? baseUrl, String? topic})> loadWebSocketConfig() async {
+    final content = await _loadConfigContent();
+    return parseWebSocketConfig(content);
+  }
+
+  /// 纯函数：从 yaml 内容解析 websocket 配置，便于单元测试。
+  static ({String? baseUrl, String? topic}) parseWebSocketConfig(String content) {
+    try {
+      final yaml = loadYaml(content) as YamlMap;
+      final ws = yaml['websocket'] as YamlMap?;
+      return (
+        baseUrl: ws?['base_url']?.toString().trim(),
+        topic: ws?['default_topic']?.toString().trim(),
+      );
+    } catch (_) {
+      return (baseUrl: null, topic: null);
+    }
+  }
+
+  /// 从 config.yaml 的 topics 节读取指定设备的 topic；缺失/空/解析失败返回 null。
+  static Future<String?> loadTopicForDevice(String device) async {
+    final content = await _loadConfigContent();
+    return parseTopicForDevice(content, device);
+  }
+
+  /// 纯函数：从 yaml 内容的 topics 节解析指定设备的 topic，便于单元测试。
+  static String? parseTopicForDevice(String content, String device) {
+    try {
+      final yaml = loadYaml(content) as YamlMap;
+      final topics = yaml['topics'] as YamlMap?;
+      final topic = topics?[device]?.toString().trim();
+      return (topic == null || topic.isEmpty) ? null : topic;
+    } catch (_) {
+      return null;
+    }
   }
 
   static String? _str(YamlMap m, String key) {

--- a/im_flutter_test/lib/websocket_config_page.dart
+++ b/im_flutter_test/lib/websocket_config_page.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 
 import 'bridge/event_bridge_handler.dart';
 import 'bridge/im_websocket_bridge.dart';
+import 'sdk_config_loader.dart';
+
+/// 本 App 实例的设备标识（deviceA/deviceB），通过构建参数 `--dart-define=DEVICE=...` 指定。
+const String kDeviceName = String.fromEnvironment('DEVICE', defaultValue: 'deviceA');
 
 /// WebSocket 桥接配置页：配置 URL/topic、手动连接/断开、查看与清空请求响应列表。
 class WebSocketConfigPage extends StatefulWidget {
@@ -26,6 +30,30 @@ class _WebSocketConfigPageState extends State<WebSocketConfigPage> {
     _topicController.text = kDefaultBridgeWebSocketTopic;
     _deviceController.text = 'deviceA';
     IMWebSocketBridge.instance.onLog = _onLog;
+    _autoConnect();
+  }
+
+  /// 从 config.yaml 读取 websocket 配置并自动建立桥接连接。
+  /// topic 优先级：topics[device] > websocket.default_topic > 默认常量。
+  /// 配置缺失/空时回退；失败不影响后续手动重连。
+  Future<void> _autoConnect() async {
+    final cfg = await SdkConfigLoader.loadWebSocketConfig();
+    final deviceTopic = await SdkConfigLoader.loadTopicForDevice(kDeviceName);
+    if (!mounted) return;
+    final baseUrl = (cfg.baseUrl == null || cfg.baseUrl!.isEmpty)
+        ? kDefaultBridgeWebSocketBaseUrl
+        : cfg.baseUrl!;
+    final topic = (deviceTopic != null && deviceTopic.isNotEmpty)
+        ? deviceTopic
+        : ((cfg.topic == null || cfg.topic!.isEmpty)
+            ? kDefaultBridgeWebSocketTopic
+            : cfg.topic!);
+    setState(() {
+      _urlController.text = baseUrl;
+      _topicController.text = topic;
+      _deviceController.text = kDeviceName;
+    });
+    await _connect();
   }
 
   @override

--- a/im_flutter_test/test/sdk_config_loader_websocket_test.dart
+++ b/im_flutter_test/test/sdk_config_loader_websocket_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:im_flutter_test/sdk_config_loader.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('parseWebSocketConfig', () {
+    test('解析正常 base_url 与 default_topic', () {
+      final cfg = SdkConfigLoader.parseWebSocketConfig('''
+websocket:
+  base_url: "ws://127.0.0.1:4000/iov/websocket/dual"
+  default_topic: "adc"
+''');
+      expect(cfg.baseUrl, 'ws://127.0.0.1:4000/iov/websocket/dual');
+      expect(cfg.topic, 'adc');
+    });
+
+    test('缺失 websocket 节时返回空字段', () {
+      final cfg = SdkConfigLoader.parseWebSocketConfig('''
+sdk_options:
+  app_key: "x#y"
+''');
+      expect(cfg.baseUrl, isNull);
+      expect(cfg.topic, isNull);
+    });
+
+    test('base_url 与 default_topic 为空字符串时返回空字段', () {
+      final cfg = SdkConfigLoader.parseWebSocketConfig('''
+websocket:
+  base_url: ""
+  default_topic: ""
+''');
+      expect(cfg.baseUrl, isEmpty);
+      expect(cfg.topic, isEmpty);
+    });
+
+    test('非法 yaml 时返回空字段而不抛异常', () {
+      final cfg = SdkConfigLoader.parseWebSocketConfig('not: [valid');
+      expect(cfg.baseUrl, isNull);
+      expect(cfg.topic, isNull);
+    });
+
+    test('值带首尾空白时去除空白', () {
+      final cfg = SdkConfigLoader.parseWebSocketConfig('''
+websocket:
+  base_url: "  ws://127.0.0.1:4000/iov/websocket/dual  "
+  default_topic: "  adc  "
+''');
+      expect(cfg.baseUrl, 'ws://127.0.0.1:4000/iov/websocket/dual');
+      expect(cfg.topic, 'adc');
+    });
+  });
+
+  test('loads websocket config from the shared asset', () async {
+    final cfg = await SdkConfigLoader.loadWebSocketConfig();
+    // 当前 config.yaml 生效的 websocket 节为非空值。
+    expect(cfg.baseUrl, isNotNull);
+    expect(cfg.baseUrl, isNotEmpty);
+    expect(cfg.topic, isNotNull);
+    expect(cfg.topic, isNotEmpty);
+  });
+
+  group('parseTopicForDevice', () {
+    const content = '''
+topics:
+  deviceA: adc
+  deviceB: adc01
+''';
+
+    test('按设备名解析 topic', () {
+      expect(SdkConfigLoader.parseTopicForDevice(content, 'deviceA'), 'adc');
+      expect(SdkConfigLoader.parseTopicForDevice(content, 'deviceB'), 'adc01');
+    });
+
+    test('设备不存在时返回 null', () {
+      expect(SdkConfigLoader.parseTopicForDevice(content, 'deviceC'), isNull);
+    });
+
+    test('缺失 topics 节时返回 null', () {
+      expect(
+        SdkConfigLoader.parseTopicForDevice('sdk_options:\n  app_key: "x#y"', 'deviceA'),
+        isNull,
+      );
+    });
+
+    test('topic 为空字符串时返回 null', () {
+      expect(
+        SdkConfigLoader.parseTopicForDevice('topics:\n  deviceA: ""', 'deviceA'),
+        isNull,
+      );
+    });
+
+    test('非法 yaml 时返回 null 而不抛异常', () {
+      expect(SdkConfigLoader.parseTopicForDevice('not: [valid', 'deviceA'), isNull);
+    });
+
+    test('值带首尾空白时去除空白', () {
+      expect(
+        SdkConfigLoader.parseTopicForDevice('topics:\n  deviceA: "  adc  "', 'deviceA'),
+        'adc',
+      );
+    });
+  });
+}

--- a/native-auto-test/Makefile
+++ b/native-auto-test/Makefile
@@ -13,10 +13,12 @@ WS_STATE_DIR ?= $(CURDIR)/.local
 .PHONY: help ws-bridge-up ws-bridge-down test-local ws-bridge-local ws-bridge-reverse \
         ws-call ws-wait create-users delete-user \
         contact-establish contact-delete contact-block contact-unblock \
-        skills-validate test test-allure test-html test-chat-strict test-chat-discover clean
+        skills-validate test test-allure test-html test-chat-strict test-chat-discover \
+        setup-emulator clean
 
 help:
 	@echo "Available targets:"
+	@echo "  setup-emulator     Prepare two minimal Android emulators (deviceA/deviceB)"
 	@echo "  ws-bridge-up       Start relay, configure emulator reverse, write local env"
 	@echo "  ws-bridge-down     Remove reverse and stop the managed local relay"
 	@echo "  test-local         Run pytest with generated local WS env [ARGS]"
@@ -34,6 +36,10 @@ help:
 	@echo "  test               Run pytest (pass ARGS=... to forward extra args)"
 	@echo "  test-allure        Run pytest with --alluredir=out/allure-results"
 	@echo "  test-html          Run pytest with HTML report to out/report.html"
+
+# --- Emulator setup (two minimal AVDs for deviceA/deviceB) ---
+setup-emulator:
+	bash skills/im-flutter-run/scripts/setup_emulator.sh
 
 # --- Local WebSocket relay ---
 ws-bridge-up:

--- a/native-auto-test/README.md
+++ b/native-auto-test/README.md
@@ -317,6 +317,9 @@ This repository includes Codex skills under `skills/` following the create-skill
   - Scripts: `scripts/create_users.py`, `scripts/delete_user.py`
 - `skills/im-contact-flow` — High-level contact flows built on WS.
   - Scripts: `scripts/contact_flow.py`
+- `skills/im-flutter-run` — One-command release E2E run (build APK → emulator → install → bridge → pytest → report).
+  - Scripts: `scripts/run.sh`
+  - No Android Studio required; see the skill's `SKILL.md` for minimal dependencies and usage.
 
 Usage examples can be found in each skill's `SKILL.md`. Make sure `config.yaml` is configured before using them.
 

--- a/native-auto-test/skills/im-flutter-run/SKILL.md
+++ b/native-auto-test/skills/im-flutter-run/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: im-flutter-run
+description: |
+  One-command local release E2E run for this repo's Flutter IM SDK test app.
+  Builds two im_flutter_test release APKs (deviceA/deviceB), boots two headless Android emulators,
+  installs the APKs, starts the local WebSocket bridge, runs pytest cases, and generates the Allure report.
+  Use when a contributor wants to run cases end-to-end without Android Studio or manual App setup.
+---
+
+# IM Flutter Run
+
+One-command end-to-end test run for `im_flutter_test` (release) + `native-auto-test` (pytest).
+
+## Minimal Dependencies (no Android Studio required)
+
+`run.sh` auto-installs the Android toolchain on first run (idempotent), so you only need:
+
+- Flutter SDK (`flutter` on PATH)
+- JDK 17+ (auto-installed via brew/apt if missing; otherwise `java` on PATH)
+- Python environment (prefers `native-auto-test/.flutter-vnev`, then `.venv`)
+- Optional: allure CLI (`npm i -g allure-commandline`); if missing, only the raw results path is printed
+
+Auto-installed if missing: Android cmdline-tools (`sdkmanager`/`avdmanager`), `emulator`, `platform-tools`, `system-images;android-34;default` (matching host arch), and two minimal AVDs (`im_flutter_test_a` / `im_flutter_test_b`).
+
+## Usage
+
+```bash
+# from the native-auto-test directory
+bash skills/im-flutter-run/scripts/run.sh
+
+# download release APKs from a specific repo
+bash skills/im-flutter-run/scripts/run.sh --repo easemob/im_flutter_sdk -q tests/client/test_client.py
+
+# build APKs locally instead of downloading (developer mode)
+bash skills/im-flutter-run/scripts/run.sh --build -q tests/client/test_client.py
+
+# keep the emulators after the run (shut down by default)
+bash skills/im-flutter-run/scripts/run.sh --keep-emulator
+```
+
+Flow: detect/install emulator env → obtain APKs (download latest release by default, or `--build` locally) → boot two emulators → install APKs → push `config.yaml` (startup injection) → `make ws-bridge-up` (relay + reverse) → launch apps (auto-connect) → `make test-local` (pytest) → `allure generate` → auto-open report.
+
+## Config effectiveness rules (important)
+
+`config.yaml` is injected at app startup (not bundled into the APK), so changing it does **not** require rebuilding the APK:
+
+| Section | Consumer | How it reaches the app |
+|---|---|---|
+| `sdk_options` (app_key, servers) | App | `run.sh` pushes `config.yaml` to the emulator's external files dir |
+| `websocket` (base_url, topic) | App | same |
+| `topics` (multi-device) | App | same |
+| `rest_api` (user provisioning) | Python side | read at runtime from the local `config.yaml` |
+
+`run.sh` pushes the local `config.yaml` to both emulators before launching. Edit it, then re-run — no rebuild needed.
+
+## Reused components
+
+- emulator setup: `scripts/setup_emulator.sh` (auto-install + create minimal AVDs)
+- relay + reverse + env: reuses `make ws-bridge-up` (`scripts/ws_bridge_local.sh` + `scripts/adb_reverse_ws_bridge.sh`)
+- pytest: reuses `make test-local` (loads `.local/ws-bridge.env`)
+- report: reuses allure (`out/allure-results` → `out/allure-report`)
+
+## Notes
+
+- The emulators run headless with software rendering (swiftshader), sufficient for API automation.
+- Two devices (deviceA/deviceB) are required; device is selected at build time via `--dart-define=DEVICE=...` and topic is resolved from `topics.deviceA`/`topics.deviceB`.
+- The script does not modify `config.yaml`, REST config, or business accounts.
+
+## References
+
+- Design: `.doc/specs/release-test-automation/design.md`
+- Test app: `../im_flutter_test/`
+- Cases and reports: `README.md`

--- a/native-auto-test/skills/im-flutter-run/openai.yaml
+++ b/native-auto-test/skills/im-flutter-run/openai.yaml
@@ -1,0 +1,8 @@
+display_name: IM Flutter Run
+short_description: Build release APK, boot emulator, install, bridge, run pytest, generate report.
+default_prompt: |
+  Run the Flutter IM SDK E2E cases locally in one command.
+  Execute scripts/run.sh from the native-auto-test directory.
+  It builds the release APK, boots a headless emulator, installs the app,
+  starts the WS bridge, runs pytest, and generates the Allure report.
+  No Android Studio needed.

--- a/native-auto-test/skills/im-flutter-run/scripts/run.sh
+++ b/native-auto-test/skills/im-flutter-run/scripts/run.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-command local release E2E run: build two APKs (deviceA/deviceB) -> boot two emulators ->
+# install -> bridge -> pytest -> report. No Android Studio required; reuses make ws-bridge-up / make test-local.
+
+usage() {
+  cat <<'EOF'
+Usage: run.sh [--build] [--repo OWNER/REPO] [--keep-emulator] [--no-open] [pytest args...]
+
+  --build           Build APKs locally instead of downloading from the latest release
+  --repo OWNER/REPO GitHub repo to download release artifacts from (default: easemob/im_flutter_sdk)
+  --keep-emulator   Keep emulators running after the run (shut down by default)
+  --no-open         Do not auto-open the report in a browser (use in CI)
+  Remaining args are passed through to pytest (simple args, e.g. -q tests/client/test_client.py)
+
+Examples:
+  run.sh
+  run.sh -q tests/client/test_client.py
+  run.sh --build -q tests/client/test_client.py
+EOF
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+native_auto_test="$(cd "$script_dir/../../.." && pwd -P)"
+repo_root="$(cd "$native_auto_test/.." && pwd -P)"
+flutter_test="$repo_root/im_flutter_test"
+
+KEEP_EMULATOR=0
+OPEN_REPORT=1
+BUILD_LOCAL=0
+GH_REPO="${GH_REPO:-easemob/im_flutter_sdk}"
+PYTEST_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build) BUILD_LOCAL=1; shift ;;
+    --repo) GH_REPO="${2:?--repo requires OWNER/REPO}"; shift 2 ;;
+    --keep-emulator) KEEP_EMULATOR=1; shift ;;
+    --no-open) OPEN_REPORT=0; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) PYTEST_ARGS+=("$1"); shift ;;
+  esac
+done
+
+fail() { echo "error: $*" >&2; exit 1; }
+
+# ---- Environment detection ----
+detect_python() {
+  local c
+  for c in "$native_auto_test/.flutter-vnev/bin/python" "$native_auto_test/.venv/bin/python"; do
+    if [[ -x "$c" ]]; then echo "$c"; return 0; fi
+  done
+  if command -v python3 >/dev/null 2>&1; then echo "python3"; return 0; fi
+  return 1
+}
+
+detect_sdk_dir() {
+  local sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+  if [[ -n "$sdk" && -d "$sdk" ]]; then echo "$sdk"; return 0; fi
+  for sdk in "$HOME/Library/Android/sdk" "$HOME/Android/Sdk"; do
+    if [[ -d "$sdk" ]]; then echo "$sdk"; return 0; fi
+  done
+  return 1
+}
+
+PY="$(detect_python)" || fail "no usable Python found (check native-auto-test/.flutter-vnev or .venv)"
+SDK_DIR="$(detect_sdk_dir)" || fail "Android SDK not found (set ANDROID_HOME or ANDROID_SDK_ROOT)"
+ADB="$SDK_DIR/platform-tools/adb"
+EMULATOR="$SDK_DIR/emulator/emulator"
+
+[[ -x "$ADB" ]] || fail "adb not found: $ADB"
+[[ -x "$EMULATOR" ]] || fail "emulator not found: $EMULATOR"
+
+if [[ "$BUILD_LOCAL" == "1" ]]; then
+  command -v flutter >/dev/null 2>&1 || fail "flutter not found; install Flutter SDK and add it to PATH (or drop --build to download release APKs)"
+else
+  command -v curl >/dev/null 2>&1 || fail "curl not found (needed to download release APKs)"
+fi
+
+# Ensure two minimal emulators exist (auto-install JDK/cmdline-tools/emulator/image/AVDs if missing, idempotent).
+AVD_A="im_flutter_test_a"
+AVD_B="im_flutter_test_b"
+bash "$script_dir/setup_emulator.sh"
+
+echo "==> Environment ready: PY=$PY AVD_A=$AVD_A AVD_B=$AVD_B SDK=$SDK_DIR"
+
+# ---- Obtain APKs: download from latest release (default) or build locally (--build) ----
+if [[ "$BUILD_LOCAL" == "1" ]]; then
+  echo "==> Building release APKs locally (deviceA/deviceB) ..."
+  (cd "$flutter_test" && flutter build apk --release --dart-define=DEVICE=deviceA)
+  cp "$flutter_test/build/app/outputs/flutter-apk/app-release.apk" /tmp/im-flutter-run-deviceA.apk
+  (cd "$flutter_test" && flutter build apk --release --dart-define=DEVICE=deviceB)
+  cp "$flutter_test/build/app/outputs/flutter-apk/app-release.apk" /tmp/im-flutter-run-deviceB.apk
+else
+  echo "==> Downloading APKs from latest release ($GH_REPO) ..."
+  BASE="https://github.com/$GH_REPO/releases/latest/download"
+  curl -fL --max-time 600 -o /tmp/im-flutter-run-deviceA.apk "$BASE/app-release-deviceA.apk"
+  curl -fL --max-time 600 -o /tmp/im-flutter-run-deviceB.apk "$BASE/app-release-deviceB.apk"
+fi
+[[ -s /tmp/im-flutter-run-deviceA.apk ]] || fail "deviceA APK missing/empty"
+[[ -s /tmp/im-flutter-run-deviceB.apk ]] || fail "deviceB APK missing/empty"
+
+# ---- Boot two emulators (fixed adb ports) ----
+SERIAL_A="emulator-5554"
+SERIAL_B="emulator-5556"
+
+echo "==> Booting emulator A ($AVD_A) -> $SERIAL_A ..."
+"$EMULATOR" -avd "$AVD_A" -port 5554 -no-window -no-audio -no-boot-anim \
+  -gpu swiftshader_indirect -no-snapshot \
+  > /tmp/im-flutter-run-emulator-A.log 2>&1 &
+EMU_A_PID=$!
+
+echo "==> Booting emulator B ($AVD_B) -> $SERIAL_B ..."
+"$EMULATOR" -avd "$AVD_B" -port 5556 -no-window -no-audio -no-boot-anim \
+  -gpu swiftshader_indirect -no-snapshot \
+  > /tmp/im-flutter-run-emulator-B.log 2>&1 &
+EMU_B_PID=$!
+
+cleanup() {
+  echo "==> Cleaning up ..."
+  (cd "$native_auto_test" && make ws-bridge-down PY="$PY" ADB="$ADB" >/dev/null 2>&1 || true)
+  if [[ "$KEEP_EMULATOR" == "0" ]]; then
+    "$ADB" -s "$SERIAL_A" emu kill >/dev/null 2>&1 || true
+    "$ADB" -s "$SERIAL_B" emu kill >/dev/null 2>&1 || true
+    # emulator 命令会 fork 出 qemu 子进程，$EMU_x_PID 未必等于 qemu pid；兜底按 avd 名强杀避免端口残留。
+    pkill -f "qemu-system.*-avd $AVD_A" >/dev/null 2>&1 || true
+    pkill -f "qemu-system.*-avd $AVD_B" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+wait_boot() {
+  local serial="$1"
+  "$ADB" -s "$serial" wait-for-device
+  while [[ "$("$ADB" -s "$serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]]; do
+    sleep 3
+  done
+}
+
+wait_boot "$SERIAL_A"
+echo "==> Emulator A boot completed"
+wait_boot "$SERIAL_B"
+echo "==> Emulator B boot completed"
+
+# ---- Install APKs ----
+echo "==> Installing release APKs ..."
+"$ADB" -s "$SERIAL_A" install -r /tmp/im-flutter-run-deviceA.apk
+"$ADB" -s "$SERIAL_B" install -r /tmp/im-flutter-run-deviceB.apk
+
+# ---- Push runtime config (startup injection; no rebuild needed) ----
+CONFIG="$native_auto_test/config.yaml"
+CONFIG_DEST="/sdcard/Android/data/com.easemob.im_flutter_test/files/config.yaml"
+if [[ -f "$CONFIG" ]]; then
+  echo "==> Pushing config.yaml to both emulators ..."
+  "$ADB" -s "$SERIAL_A" push "$CONFIG" "$CONFIG_DEST" >/dev/null
+  "$ADB" -s "$SERIAL_B" push "$CONFIG" "$CONFIG_DEST" >/dev/null
+else
+  echo "==> config.yaml not found ($CONFIG); App will fall back to bundled asset config"
+fi
+
+# ---- Bridge (relay + reverse for all emulator-*) ----
+echo "==> Starting local WebSocket bridge ..."
+(cd "$native_auto_test" && make ws-bridge-up PY="$PY" ADB="$ADB")
+
+# ---- Launch both apps (auto-connect) ----
+echo "==> Launching apps (auto-connect) ..."
+"$ADB" -s "$SERIAL_A" shell am start -n com.easemob.im_flutter_test/.MainActivity
+"$ADB" -s "$SERIAL_B" shell am start -n com.easemob.im_flutter_test/.MainActivity
+sleep 8
+
+# ---- Run pytest ----
+echo "==> Running pytest ..."
+rm -rf "$native_auto_test/out/allure-results"
+set +e
+(cd "$native_auto_test" && make test-local PY="$PY" ADB="$ADB" ARGS="--alluredir=out/allure-results ${PYTEST_ARGS[*]}")
+PYTEST_EXIT=$?
+set -e
+if [[ "$PYTEST_EXIT" != "0" ]]; then
+  echo "==> pytest exited with code $PYTEST_EXIT (report will still be generated)"
+fi
+
+# ---- Report ----
+echo "==> Generating report ..."
+if command -v allure >/dev/null 2>&1; then
+  rm -rf "$native_auto_test/out/allure-report"
+  (cd "$native_auto_test" && allure generate out/allure-results -o out/allure-report --clean)
+  echo "Report: $native_auto_test/out/allure-report/"
+  if [[ "$OPEN_REPORT" == "1" ]]; then
+    echo "==> Opening report in browser (Ctrl-C to stop the server and finish) ..."
+    (cd "$native_auto_test" && allure open out/allure-report)
+  else
+    echo "Open it manually (HTTP, not file://): (cd $native_auto_test && allure open out/allure-report)"
+  fi
+else
+  echo "allure CLI not found; raw results at: $native_auto_test/out/allure-results/"
+  echo "Install allure (e.g. npm i -g allure-commandline), then run:"
+  echo "  allure generate out/allure-results -o out/allure-report --clean"
+fi
+
+exit "$PYTEST_EXIT"

--- a/native-auto-test/skills/im-flutter-run/scripts/setup_emulator.sh
+++ b/native-auto-test/skills/im-flutter-run/scripts/setup_emulator.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fully automated, idempotent Android emulator setup for the Flutter IM SDK tests.
+# Detects each piece and installs it if missing; skips what already exists:
+#   JDK -> cmdline-tools -> emulator/platform-tools -> system image -> two minimal AVDs
+# No Android Studio required.
+
+fail() { echo "error: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+# ---- OS / arch ----
+case "$(uname -s)" in
+  Darwin) OS="mac" ;;
+  Linux)  OS="linux" ;;
+  *) fail "unsupported OS: $(uname -s)" ;;
+esac
+
+case "$(uname -m)" in
+  arm64|aarch64) ABI="arm64-v8a" ;;
+  x86_64|amd64)  ABI="x86_64" ;;
+  *) fail "unsupported arch: $(uname -m)" ;;
+esac
+
+# ---- SDK root ----
+detect_sdk_root() {
+  local sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+  if [[ -n "$sdk" && -d "$sdk" ]]; then echo "$sdk"; return 0; fi
+  for sdk in "$HOME/Library/Android/sdk" "$HOME/Android/Sdk"; do
+    if [[ -d "$sdk" ]]; then echo "$sdk"; return 0; fi
+  done
+  return 1
+}
+
+if sdk="$(detect_sdk_root)"; then
+  SDK_ROOT="$sdk"
+else
+  SDK_ROOT="$HOME/Library/Android/sdk"
+  [[ "$OS" == "linux" ]] && SDK_ROOT="$HOME/Android/Sdk"
+  info "SDK root not found, using $SDK_ROOT"
+  mkdir -p "$SDK_ROOT"
+fi
+export ANDROID_HOME="$SDK_ROOT"
+export ANDROID_SDK_ROOT="$SDK_ROOT"
+
+# ---- 1. JDK (17+) ----
+ensure_java() {
+  if command -v java >/dev/null 2>&1; then
+    info "Java found: $(java -version 2>&1 | head -1)"
+    return 0
+  fi
+  info "Java not found, attempting auto-install ..."
+  if [[ "$OS" == "mac" ]] && command -v brew >/dev/null 2>&1; then
+    brew install --cask temurin17 >/dev/null 2>&1 || true
+    export JAVA_HOME="$(/usr/libexec/java_home -v 17 2>/dev/null || true)"
+  elif [[ "$OS" == "linux" ]] && command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update -qq && sudo apt-get install -y -qq openjdk-17-jdk-headless
+  fi
+  command -v java >/dev/null 2>&1 || fail "JDK 17+ required; install it and add java to PATH"
+  info "Java installed"
+}
+
+# ---- 2. cmdline-tools (sdkmanager / avdmanager) ----
+CMD_TOOLS_VERSION="11076708"
+SM="$SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+AM="$SDK_ROOT/cmdline-tools/latest/bin/avdmanager"
+
+ensure_cmdline_tools() {
+  if [[ -x "$SM" && -x "$AM" ]]; then
+    info "cmdline-tools found, skip"
+    return 0
+  fi
+  info "cmdline-tools not found, downloading ..."
+  local url="https://dl.google.com/android/repository/commandlinetools-${OS}-${CMD_TOOLS_VERSION}_latest.zip"
+  local zip="/tmp/commandlinetools.zip"
+  local tmp="/tmp/cmdline-tools-extract"
+  curl -fL --max-time 600 -o "$zip" "$url"
+  rm -rf "$tmp"; mkdir -p "$tmp"
+  unzip -q "$zip" -d "$tmp"
+  mkdir -p "$SDK_ROOT/cmdline-tools"
+  rm -rf "$SDK_ROOT/cmdline-tools/latest"
+  mv "$tmp/cmdline-tools" "$SDK_ROOT/cmdline-tools/latest"
+  rm -rf "$tmp" "$zip"
+  info "cmdline-tools installed"
+}
+
+# ---- 3. emulator + platform-tools ----
+ensure_emulator() {
+  local need=""
+  [[ -x "$SDK_ROOT/emulator/emulator" ]] || need="emulator"
+  [[ -x "$SDK_ROOT/platform-tools/adb" ]] || need="$need platform-tools"
+  if [[ -n "$need" ]]; then
+    info "Installing: $need ..."
+    yes | "$SM" --sdk_root="$SDK_ROOT" $need >/dev/null 2>&1
+    info "Installed: $need"
+  else
+    info "emulator + platform-tools found, skip"
+  fi
+}
+
+# ---- 4. system image ----
+IMAGE="system-images;android-34;default;$ABI"
+
+ensure_image() {
+  if "$SM" --sdk_root="$SDK_ROOT" --list_installed 2>/dev/null | grep -q "$IMAGE"; then
+    info "system image found, skip"
+    return 0
+  fi
+  info "Downloading system image $IMAGE (first run only) ..."
+  yes | "$SM" --sdk_root="$SDK_ROOT" "$IMAGE" >/dev/null 2>&1
+  info "system image installed"
+}
+
+# ---- 5. two minimal AVDs ----
+AVD_A="im_flutter_test_a"
+AVD_B="im_flutter_test_b"
+
+MIN_CONFIG='hw.lcd.width=720
+hw.lcd.height=1280
+hw.lcd.density=160
+hw.gpu.mode=off
+hw.gpu.enabled=no
+disk.dataPartition.size=4G
+hw.ramSize=2G
+hw.cpu.ncore=4'
+
+apply_min_config() {
+  local cfg="$1"
+  grep -vE '^(hw\.lcd\.width|hw\.lcd\.height|hw\.lcd\.density|hw\.gpu\.mode|hw\.gpu\.enabled|disk\.dataPartition\.size|hw\.ramSize|hw\.cpu\.ncore)=' \
+    "$cfg" > "$cfg.tmp"
+  mv "$cfg.tmp" "$cfg"
+  printf '%s\n' "$MIN_CONFIG" >> "$cfg"
+}
+
+create_avd() {
+  local name="$1"
+  if "$SDK_ROOT/emulator/emulator" -list-avds 2>/dev/null | grep -qx "$name"; then
+    info "AVD $name exists, skip"
+    return 0
+  fi
+  info "Creating minimal AVD $name ..."
+  echo "no" | "$AM" create avd -n "$name" -k "$IMAGE" --device pixel_2 --force >/dev/null 2>&1
+  local cfg="$HOME/.android/avd/$name.avd/config.ini"
+  [[ -f "$cfg" ]] || fail "AVD config not found: $cfg"
+  apply_min_config "$cfg"
+  info "AVD $name created ($ABI, 720x1280, gpu off)"
+}
+
+# ---- main ----
+ensure_java
+ensure_cmdline_tools
+ensure_emulator
+ensure_image
+create_avd "$AVD_A"
+create_avd "$AVD_B"
+
+info "Emulators ready: $AVD_A, $AVD_B"
+echo "    AVD_A=$AVD_A"
+echo "    AVD_B=$AVD_B"


### PR DESCRIPTION
- Support release build: R8 keep rules for Hyphenate SDK (JNI/reflection)
- App auto-connect + startup config injection (external file, no rebuild)
- Add im-flutter-run skill: auto emulator setup + APK download/build + pytest + allure report
- Add GitHub Actions release build workflow (remote maven 4.23.0)
- Add specs under .doc/specs/release-test-automation