### PR TITLE
fix: enforce Java 17+ / Python 3.10+, show sdkmanager download progress

### DIFF
--- a/native-auto-test/README.md
+++ b/native-auto-test/README.md
@@ -79,8 +79,9 @@ bash skills/im-flutter-run/scripts/run.sh --no-open
 
 ## 环境
 
-- Python 3.9+
-- 安装依赖：`pip install -r requirements.txt`
+- Python 3.10+（代码使用 `str | None` 等 PEP 604 语法，3.9 会报语法错误）
+- 安装依赖：`pip install -r requirements.txt`（或由 `run.sh` 自动创建 venv 并安装）
+- 首次运行需从 Google 下载 emulator 与系统镜像（约 1.6G），耗时几分钟，请耐心等待或配置代理
 
 `requirements.txt` 将 `websockets` 限制为 `>=11.0,<17.0`。当前 relay 和现有
 `ws_client.py` 都依赖 legacy API；在两者一起迁移到新 asyncio API 前，不要移除该

--- a/native-auto-test/skills/im-flutter-run/SKILL.md
+++ b/native-auto-test/skills/im-flutter-run/SKILL.md
@@ -16,7 +16,7 @@ One-command end-to-end test run for `im_flutter_test` (release) + `native-auto-t
 `run.sh` auto-installs the full toolchain on first run (idempotent), so you only need:
 
 - A network connection to GitHub and your test environment
-- Python 3.9+ (`python3` on PATH; the venv is created automatically)
+- Python 3.10+ (`python3` on PATH; the venv is created automatically)
 
 Auto-installed if missing: JDK 17+, Android cmdline-tools, `emulator`, `platform-tools`, `system-images;android-34;default` (matching host arch), two minimal AVDs (`im_flutter_test_a` / `im_flutter_test_b`), and the Python venv + dependencies.
 

--- a/native-auto-test/skills/im-flutter-run/scripts/run.sh
+++ b/native-auto-test/skills/im-flutter-run/scripts/run.sh
@@ -48,7 +48,11 @@ fail() { echo "error: $*" >&2; exit 1; }
 ensure_python_env() {
   local venv="$native_auto_test/.venv"
   if [[ ! -x "$venv/bin/python" ]]; then
-    command -v python3 >/dev/null 2>&1 || fail "python3 not found; install Python 3.9+"
+    command -v python3 >/dev/null 2>&1 || fail "python3 not found; install Python 3.10+"
+    # 代码使用 `str | None` 等 PEP 604 语法，要求 Python 3.10+
+    if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)'; then
+      fail "Python 3.10+ required (found: $(python3 --version 2>&1))"
+    fi
     echo "==> Creating Python venv ($venv) ..."
     python3 -m venv "$venv"
   fi

--- a/native-auto-test/skills/im-flutter-run/scripts/setup_emulator.sh
+++ b/native-auto-test/skills/im-flutter-run/scripts/setup_emulator.sh
@@ -45,19 +45,61 @@ export ANDROID_SDK_ROOT="$SDK_ROOT"
 
 # ---- 1. JDK (17+) ----
 ensure_java() {
+  local ver=""
+
+  # 1. Check PATH java version
   if command -v java >/dev/null 2>&1; then
-    info "Java found: $(java -version 2>&1 | head -1)"
-    return 0
+    ver=$(java -version 2>&1 | head -1 | grep -oE '"[0-9]+' | tr -d '"')
+    if [[ -n "$ver" && "$ver" -ge 17 ]]; then
+      info "Java 17+ found: $(java -version 2>&1 | head -1)"
+      return 0
+    fi
+    info "Java found but too old (version ${ver:-unknown}), looking for Java 17+ ..."
   fi
-  info "Java not found, attempting auto-install ..."
+
+  # 2. macOS: prefer an already-installed Java 17 (brew openjdk@17 or java_home)
+  if [[ "$OS" == "mac" ]]; then
+    local candidates=(
+      "/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home"
+      "/usr/local/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home"
+    )
+    local jh
+    jh="$(/usr/libexec/java_home -v 17 2>/dev/null || true)"
+    [[ -n "$jh" ]] && candidates+=("$jh")
+    local c
+    for c in "${candidates[@]}"; do
+      if [[ -x "$c/bin/java" ]]; then
+        export JAVA_HOME="$c"
+        export PATH="$JAVA_HOME/bin:$PATH"
+        info "Using Java 17 from: $c"
+        return 0
+      fi
+    done
+  fi
+
+  # 3. Auto-install
+  info "Java 17+ not found, attempting auto-install ..."
   if [[ "$OS" == "mac" ]] && command -v brew >/dev/null 2>&1; then
-    brew install --cask temurin17 >/dev/null 2>&1 || true
-    export JAVA_HOME="$(/usr/libexec/java_home -v 17 2>/dev/null || true)"
+    brew install --cask temurin17 || true
+    local c
+    for c in "/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home" \
+             "/usr/local/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home"; do
+      if [[ -x "$c/bin/java" ]]; then
+        export JAVA_HOME="$c"
+        export PATH="$JAVA_HOME/bin:$PATH"
+        info "Java 17 installed at: $c"
+        return 0
+      fi
+    done
   elif [[ "$OS" == "linux" ]] && command -v apt-get >/dev/null 2>&1; then
     sudo apt-get update -qq && sudo apt-get install -y -qq openjdk-17-jdk-headless
   fi
+
+  # Final validation
   command -v java >/dev/null 2>&1 || fail "JDK 17+ required; install it and add java to PATH"
-  info "Java installed"
+  ver=$(java -version 2>&1 | head -1 | grep -oE '"[0-9]+' | tr -d '"')
+  [[ -n "$ver" && "$ver" -ge 17 ]] || fail "JDK 17+ required (found version: ${ver:-unknown})"
+  info "Java 17+ ready: $(java -version 2>&1 | head -1)"
 }
 
 # ---- 2. cmdline-tools (sdkmanager / avdmanager) ----
@@ -90,8 +132,8 @@ ensure_emulator() {
   [[ -x "$SDK_ROOT/emulator/emulator" ]] || need="emulator"
   [[ -x "$SDK_ROOT/platform-tools/adb" ]] || need="$need platform-tools"
   if [[ -n "$need" ]]; then
-    info "Installing: $need ..."
-    yes | "$SM" --sdk_root="$SDK_ROOT" $need >/dev/null 2>&1
+    info "Installing: $need (this downloads from Google, may take a while) ..."
+    yes | "$SM" --sdk_root="$SDK_ROOT" $need
     info "Installed: $need"
   else
     info "emulator + platform-tools found, skip"
@@ -106,8 +148,8 @@ ensure_image() {
     info "system image found, skip"
     return 0
   fi
-  info "Downloading system image $IMAGE (first run only) ..."
-  yes | "$SM" --sdk_root="$SDK_ROOT" "$IMAGE" >/dev/null 2>&1
+  info "Downloading system image $IMAGE (first run only, may take a while) ..."
+  yes | "$SM" --sdk_root="$SDK_ROOT" "$IMAGE"
   info "system image installed"
 }
 


### PR DESCRIPTION
- setup_emulator.sh: check Java version and auto-locate Java 17 (brew openjdk@17 / java_home)
- setup_emulator.sh: show sdkmanager download progress instead of hiding output
- run.sh: check Python 3.10+ (code uses PEP 604 `str | None` syntax)
- README/SKILL.md: correct Python requirement to 3.10+, note first-run image download